### PR TITLE
Implementing nrf_802154_sleep_if_idle() function.

### DIFF
--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -288,6 +288,17 @@ bool nrf_802154_sleep(void)
     return result;
 }
 
+nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void)
+{
+    nrf_802154_sleep_error_t result;
+    nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_SLEEP);
+    
+    result = nrf_802154_request_sleep(NRF_802154_TERM_NONE) ? NRF_802154_SLEEP_ERROR_NONE : NRF_802154_SLEEP_ERROR_BUSY;
+    
+    nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_SLEEP);
+    return result;
+}
+
 bool nrf_802154_receive(void)
 {
     bool result;

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -263,6 +263,19 @@ nrf_802154_state_t nrf_802154_state_get(void);
  */
 bool nrf_802154_sleep(void);
 
+/**
+ * @brief Change radio state to sleep if radio is idle.
+ *
+ * Sleep state is the lowest power state. In this state, the radio cannot transmit or receive
+ * frames. It is the only state in which the driver releases the high-frequency clock and does not
+ * request timeslots from a radio arbiter.
+ *
+ * @note If another module requests it, the high-frequency clock may be enabled even in radio sleep
+ *       state.
+ *
+ * @retval  NRF_802154_SLEEP_ERROR_NONE  If the radio changes its state to low power mode.
+ * @retval  NRF_802154_SLEEP_ERROR_BUSY  If the driver could not schedule changing state.
+ */
 nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void);
 
 /**

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -263,6 +263,8 @@ nrf_802154_state_t nrf_802154_state_get(void);
  */
 bool nrf_802154_sleep(void);
 
+nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void);
+
 /**
  * @brief Change radio state to receive.
  *

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -97,6 +97,14 @@ typedef uint8_t nrf_802154_cca_error_t;
 #define NRF_802154_CCA_ERROR_ABORTED          0x01 //!< Procedure was aborted by another driver operation with FORCE priority.
 
 /**
+ * @brief Possible errors during sleep procedure call.
+ */
+typedef uint8_t nrf_802154_sleep_error_t;
+
+#define NRF_802154_SLEEP_ERROR_NONE           0x00 //!< There is no error.
+#define NRF_802154_SLEEP_ERROR_BUSY           0x01 //!< The driver cannot enter sleep state due to ongoing operation.
+ 
+/**
  * @brief Termination level selected for a particular request.
  *
  * Each request can terminate an ongoing operation. This type selects which operation should be


### PR DESCRIPTION
According to the polling mechanism stated in MAC specification, ED sends Data Request to a router, then  router replies with ACK. If pending bit is set ED start waiting for the packet for a certain constant period of time. Then ED is able to go to sleep.
However, if a timeout occurs during the reception of the packet, the driver will notify us by calling nrf_802154_receive_failed with NRF_DRV_RADIO802154_TX_ERROR_ABORTED code in that case. 

-----

The nrf_802154_sleep_if_idle() function should forbid radio to change state if PSDU is being recived.
