### PR TITLE
Preserve RTC interrupt status while leaving critical sections

### DIFF
--- a/src/nrf_802154_request_swi.c
+++ b/src/nrf_802154_request_swi.c
@@ -44,11 +44,18 @@
 #include "nrf_802154_core.h"
 #include "nrf_802154_critical_section.h"
 #include "nrf_802154_debug.h"
+#include "nrf_802154_utils.h"
 #include "nrf_802154_rx_buffer.h"
 #include "nrf_802154_swi.h"
 #include "hal/nrf_radio.h"
 
 #include <nrf.h>
+
+/** Assert if SWI interrupt is disabled. */
+static inline void assert_interrupt_status(void)
+{
+    assert(nrf_is_nvic_irq_enabled(NRF_802154_SWI_IRQN));
+}
 
 #define REQUEST_FUNCTION(func_core, func_swi, ...)                                                 \
     bool result = false;                                                                           \
@@ -59,6 +66,7 @@
     }                                                                                              \
     else                                                                                           \
     {                                                                                              \
+        assert_interrupt_status();                                                                 \
         func_swi(__VA_ARGS__, &result);                                                            \
     }                                                                                              \
                                                                                                    \
@@ -73,6 +81,7 @@
     }                                                                                              \
     else                                                                                           \
     {                                                                                              \
+        assert_interrupt_status();                                                                 \
         func_swi(&result);                                                                         \
     }                                                                                              \
                                                                                                    \

--- a/src/nrf_802154_utils.h
+++ b/src/nrf_802154_utils.h
@@ -33,6 +33,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include "nrf.h"
 
 /**
  * @defgroup nrf_802154_utils Utils definitions used in the 802.15.4 driver.
@@ -136,6 +137,19 @@ static inline uint64_t NRF_802154_US_TO_RTC_TICKS(uint64_t time)
     result += u1;
 
     return result;
+}
+
+/**@brief Checks if the provided interrupt is currently enabled.
+ *
+ * @note This function is valid only for ARM Cortex-M4 core.
+ *
+ * @params IRQn  Interrupt number.
+ *
+ * @returns  Zero if interrupt is disabled, non-zero value otherwise.
+ */
+static inline uint32_t nrf_is_nvic_irq_enabled(IRQn_Type IRQn)
+{
+    return (NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)]) & ((uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL)));
 }
 
 /**


### PR DESCRIPTION
If radio driver is used in a multi protocol flavor, it is possible to receive radio interrupts with all other interrupts masked (see `sd_nvic_critical_region_enter`). 
In such case, it is required to keep the timer interrupt disabled while application is inside its critical section.