### PR TITLE
[style]  add code style checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018, Nordic Semiconductor ASA
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   1. Redistributions of source code must retain the above copyright notice, this
+#      list of conditions and the following disclaimer.
+#
+#   2. Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+#   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+language: C
+sudo: false
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env: BUILD_TYPE=style
+      addons:
+        apt:
+          update: true
+          packages:
+            - cmake
+
+before_install:
+  - |-
+    if [ "x${BUILD_TYPE}" != "style" ];
+    then
+        wget https://github.com/uncrustify/uncrustify/archive/uncrustify-0.66.1.tar.gz &&
+        tar xzf uncrustify-0.66.1.tar.gz                                               &&
+        cd uncrustify-uncrustify-0.66.1                                                &&
+        mkdir build                                                                    &&
+        cd build                                                                       &&
+        cmake -DCMAKE_BUILD_TYPE=Release ..                                            &&
+        make -j                                                                        &&
+        export PATH=$PWD:$PATH                                                         &&
+        cd ../../                                                                      &&
+        uncrustify --version
+    fi
+
+script:
+  - if [ "x${BUILD_TYPE}" != "style" ]; then ./scripts/pretty.sh check; fi

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -44,10 +44,11 @@ input_tab_size = 4
 ## Indenting
 ##################################################################################
 
-indent_columns     = 4
-indent_switch_case = 4
-indent_with_tabs   = 0
-indent_paren_close = 1
+indent_columns      = 4
+indent_switch_case  = 4
+indent_with_tabs    = 0
+indent_paren_close  = 1
+indent_align_assign = 1
 
 ##################################################################################
 ## Spacing options
@@ -103,46 +104,48 @@ align_var_def_thresh     = 30
 align_assign_span        = 1
 align_assign_thresh      = 30
 align_func_params        = true
-align_right_cmt_span     = 3
+align_right_cmt_span     = 4
 align_right_cmt_at_col   = 2
 align_pp_define_gap      = 1
 align_pp_define_span     = 3
-align_var_struct_span    = 1
+align_var_struct_span    = 3
 align_var_struct_gap     = 1
 align_nl_cont            = true
 align_enum_equ_span      = 1
-align_enum_equ_thresh    = 30
+align_enum_equ_thresh    = 10
 align_pp_define_together = 1
 
 ##################################################################################
 ## Newline options
 ##################################################################################
 
-nl_enum_brace       = add
-nl_union_brace      = add
-nl_struct_brace     = add
-nl_do_brace         = add
-nl_if_brace         = add
-nl_for_brace        = add
-nl_else_brace       = add
-nl_while_brace      = add
-nl_switch_brace     = add
-nl_brace_while      = add
-nl_brace_else       = add
-nl_fcall_brace      = add
-nl_fdef_brace       = add
-nl_func_var_def_blk = 1
-nl_before_if        = ignore
-nl_before_for       = add
-nl_before_switch    = add
-nl_before_while     = add
-nl_before_case      = true
-nl_before_do        = add
-nl_func_decl_end    = remove
-nl_func_def_end     = remove
-nl_define_macro     = true
-nl_max              = 2
-nl_after_func_body = 2
+nl_enum_brace             = add
+nl_union_brace            = add
+nl_struct_brace           = add
+nl_do_brace               = add
+nl_if_brace               = add
+nl_for_brace              = add
+nl_else_brace             = add
+nl_while_brace            = add
+nl_switch_brace           = add
+nl_brace_while            = add
+nl_brace_else             = add
+nl_fcall_brace            = add
+nl_fdef_brace             = add
+nl_func_var_def_blk       = 1
+nl_before_if              = ignore
+nl_before_for             = add
+nl_before_switch          = add
+nl_before_while           = add
+nl_before_case            = true
+nl_before_do              = add
+nl_func_decl_end          = remove
+nl_func_def_end           = remove
+nl_define_macro           = true
+nl_max                    = 2
+nl_after_func_body        = 2
+nl_while_leave_one_liners = true
+nl_var_def_blk_end        = 2
 
 ##################################################################################
 ## Length options

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,152 @@
+#
+# Copyright (c) 2018, Nordic Semiconductor ASA
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   1. Redistributions of source code must retain the above copyright notice, this
+#      list of conditions and the following disclaimer.
+#
+#   2. Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+#   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# Uncrustify config file for Nordic Semiconductor Firmware Coding Standard.
+#
+# Check http://uncrustify.sourceforge.net/default.cfg to see all parameters.
+#
+
+##################################################################################
+## General options
+##################################################################################
+
+newlines       = auto
+input_tab_size = 4
+
+##################################################################################
+## Indenting
+##################################################################################
+
+indent_columns     = 4
+indent_switch_case = 4
+indent_with_tabs   = 0
+indent_paren_close = 1
+
+##################################################################################
+## Spacing options
+##################################################################################
+
+sp_before_sparen         = force
+sp_assign                = force
+sp_arith                 = force
+sp_bool                  = force
+sp_compare               = force
+sp_incdec                = remove
+sp_not                   = remove
+sp_inv                   = remove
+sp_sign                  = remove
+sp_before_ptr_star       = force
+sp_after_ptr_star        = force
+sp_between_ptr_star      = remove
+sp_deref                 = remove
+sp_addr                  = remove
+sp_after_byref           = force
+sp_before_byref          = force
+sp_cond_question         = force
+sp_cond_colon            = force
+sp_member                = remove
+sp_before_square         = remove
+sp_before_squares        = remove
+sp_inside_square         = remove
+sp_inside_paren          = remove
+sp_func_def_paren        = remove
+sp_func_call_paren       = remove
+sp_func_proto_paren      = remove
+sp_inside_fparen         = remove
+sp_special_semi          = remove
+sp_after_comma           = force
+sp_after_semi_for_empty  = remove
+sp_after_semi_for        = force
+sp_cmt_cpp_start         = force
+sp_return_paren          = force
+sp_sizeof_paren          = remove
+sp_before_tr_emb_cmt     = add
+sp_num_before_tr_emb_cmt = 2
+sp_after_cast            = remove
+
+##################################################################################
+## Code alignment
+##################################################################################
+
+align_var_def_colon      = true
+align_var_def_span       = 1
+align_var_def_inline     = true
+align_var_def_star_style = 2
+align_var_def_thresh     = 30
+align_assign_span        = 1
+align_assign_thresh      = 30
+align_func_params        = true
+align_right_cmt_span     = 3
+align_right_cmt_at_col   = 2
+align_pp_define_gap      = 1
+align_pp_define_span     = 3
+align_var_struct_span    = 1
+align_var_struct_gap     = 1
+align_nl_cont            = true
+align_enum_equ_span      = 1
+align_enum_equ_thresh    = 30
+align_pp_define_together = 1
+
+##################################################################################
+## Newline options
+##################################################################################
+
+nl_enum_brace       = add
+nl_union_brace      = add
+nl_struct_brace     = add
+nl_do_brace         = add
+nl_if_brace         = add
+nl_for_brace        = add
+nl_else_brace       = add
+nl_while_brace      = add
+nl_switch_brace     = add
+nl_brace_while      = add
+nl_brace_else       = add
+nl_fcall_brace      = add
+nl_fdef_brace       = add
+nl_func_var_def_blk = 1
+nl_before_if        = ignore
+nl_before_for       = add
+nl_before_switch    = add
+nl_before_while     = add
+nl_before_case      = true
+nl_before_do        = add
+nl_func_decl_end    = remove
+nl_func_def_end     = remove
+nl_define_macro     = true
+nl_max              = 2
+nl_after_func_body = 2
+
+##################################################################################
+## Length options
+##################################################################################
+
+code_width         = 100
+ls_func_split_full = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contribution
+
+Feel free to file code related issues on [GitHub Issues](https://github.com/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver/issues) and/or submit a pull request. In order to accept your pull request, we need you to sign our Contributor License Agreement (CLA). You will see instructions for doing this after having submitted your first pull request. You only need to sign the CLA once, so if you have already done it for another project in the NordicSemiconductor organization, you are good to go.
+
+## Coding Standard
+
+The nRF IEEE 802.15.4 radio driver uses Nordic Semiconductor Firmware Coding Standard on all code located in [src](src) directory.
+
+Before submitting a pull request, please ensure that your code passes the baseline code style checks.
+
+Use the `pretty.sh` script to automatically check or reformat the code:
+
+```bash 
+# Perform style checking
+./scripts/pretty.sh check
+
+# Perform full reformat by modyfing all source code
+./scripts/pretty.sh
+```
+
+The `pretty.sh` script relies on [uncrustify-0.66.1](https://github.com/uncrustify/uncrustify/releases/tag/uncrustify-0.66.1).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # nRF IEEE 802.15.4 radio driver
 
+[![Build Status][travis-svg]][travis]
+
+[travis]: https://travis-ci.org/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver
+[travis-svg]: https://travis-ci.org/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver.svg?branch=master
+
 The nRF IEEE 802.15.4 radio driver implements the IEEE 802.15.4 PHY layer on the Nordic Semiconductor nRF52840 SoC.
 
 The architecture of the nRF IEEE 802.15.4 radio driver is independent of the OS and IEEE 802.15.4 MAC layer.

--- a/scripts/pretty.sh
+++ b/scripts/pretty.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018, Nordic Semiconductor ASA
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   1. Redistributions of source code must retain the above copyright notice, this
+#      list of conditions and the following disclaimer.
+#
+#   2. Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+#   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+shopt -s globstar
+
+##################################################################################
+## Configuration
+##################################################################################
+
+CODE_PATH="./src"
+
+if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    UNCRUSTIFY_BIN="$(which uncrustify)"
+else
+    UNCRUSTIFY_BIN="$(where uncrustify)"
+fi
+
+UNCRUSTIFY_CFG=".uncrustify.cfg"
+UNCRUSTIFY_LANG="C"
+
+if [[ -n "$1" && $1 = "check" ]]; then UNCRUSTIFY_CHECK=1; fi
+
+##################################################################################
+## Execution
+##################################################################################
+
+# Check if binary has been found
+$UNCRUSTIFY_BIN --version || die
+
+for file in $CODE_PATH/**/*
+do
+    if [ -f "$file" ];
+    then
+        if [ -n "$UNCRUSTIFY_CHECK" ];
+        then
+            $UNCRUSTIFY_BIN -c $UNCRUSTIFY_CFG -l $UNCRUSTIFY_LANG -q -f "$file" | diff -u "$file" - || pretty_check_fail=1
+        else
+            $UNCRUSTIFY_BIN -c $UNCRUSTIFY_CFG -l $UNCRUSTIFY_LANG --no-backup "$file"
+        fi
+    fi
+done
+
+if [ -n "$pretty_check_fail" ];
+then
+    echo "ERROR: Code style issues detected. Please make sure to run ./scripts/pretty.sh script."
+    exit 1
+else
+    echo "SUCCESS"
+fi

--- a/src/fem/nrf_fem_control.c
+++ b/src/fem/nrf_fem_control.c
@@ -275,6 +275,7 @@ void nrf_fem_control_timer_set(nrf_fem_control_pin_t  pin,
     if (pin_is_enabled(pin))
     {
         uint32_t target_time = nrf_fem_control_delay_get(pin);
+
         nrf_timer_shorts_enable(NRF_FEM_TIMER_INSTANCE, short_mask);
         nrf_timer_cc_write(NRF_FEM_TIMER_INSTANCE, timer_cc_channel, target_time);
     }

--- a/src/fem/nrf_fem_control.c
+++ b/src/fem/nrf_fem_control.c
@@ -52,7 +52,7 @@
 
 #if ENABLE_FEM
 
-static nrf_fem_control_cfg_t m_nrf_fem_control_cfg;     /**< FEM controller configuration. */
+static nrf_fem_control_cfg_t m_nrf_fem_control_cfg; /**< FEM controller configuration. */
 
 /** Check whether pin is valid and enabled. */
 static bool pin_is_enabled(nrf_fem_control_pin_t pin)
@@ -102,14 +102,14 @@ static void gpiote_configure(void)
     nrf_gpiote_task_configure(m_nrf_fem_control_cfg.lna_gpiote_ch_id,
                               m_nrf_fem_control_cfg.lna_cfg.gpio_pin,
                               (nrf_gpiote_polarity_t)GPIOTE_CONFIG_POLARITY_None,
-                              (nrf_gpiote_outinit_t)!m_nrf_fem_control_cfg.lna_cfg.active_high);
+                              (nrf_gpiote_outinit_t) !m_nrf_fem_control_cfg.lna_cfg.active_high);
 
     nrf_gpiote_task_enable(m_nrf_fem_control_cfg.lna_gpiote_ch_id);
 
     nrf_gpiote_task_configure(m_nrf_fem_control_cfg.pa_gpiote_ch_id,
                               m_nrf_fem_control_cfg.pa_cfg.gpio_pin,
                               (nrf_gpiote_polarity_t)GPIOTE_CONFIG_POLARITY_None,
-                              (nrf_gpiote_outinit_t)!m_nrf_fem_control_cfg.pa_cfg.active_high);
+                              (nrf_gpiote_outinit_t) !m_nrf_fem_control_cfg.pa_cfg.active_high);
 
     nrf_gpiote_task_enable(m_nrf_fem_control_cfg.pa_gpiote_ch_id);
 }
@@ -125,12 +125,12 @@ static void ppi_init(void)
     nrf_ppi_channel_and_fork_endpoint_setup(
         (nrf_ppi_channel_t)m_nrf_fem_control_cfg.ppi_ch_id_clr,
         (uint32_t)(&NRF_RADIO->EVENTS_DISABLED),
-        (m_nrf_fem_control_cfg.lna_cfg.active_high ? 
-            (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id]) : 
-            (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id])),
-        (m_nrf_fem_control_cfg.pa_cfg.active_high ? 
-            (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id]) : 
-            (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id])));
+        (m_nrf_fem_control_cfg.lna_cfg.active_high ?
+         (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id]) :
+         (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id])),
+        (m_nrf_fem_control_cfg.pa_cfg.active_high ?
+         (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id]) :
+         (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id])));
 }
 
 /** Setup PPI to set LNA pin on a timer event. */
@@ -141,8 +141,8 @@ static void ppi_lna_enable_setup(nrf_timer_cc_channel_t timer_cc_channel)
         (nrf_ppi_channel_t)m_nrf_fem_control_cfg.ppi_ch_id_set,
         (uint32_t)(&NRF_FEM_TIMER_INSTANCE->EVENTS_COMPARE[timer_cc_channel]),
         (m_nrf_fem_control_cfg.lna_cfg.active_high ?
-            (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id]) :
-            (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id])));
+         (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id]) :
+         (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id])));
 }
 
 /** Setup PPI to set PA pin on a timer event. */
@@ -153,8 +153,8 @@ static void ppi_pa_enable_setup(nrf_timer_cc_channel_t timer_cc_channel)
         (nrf_ppi_channel_t)m_nrf_fem_control_cfg.ppi_ch_id_set,
         (uint32_t)(&NRF_FEM_TIMER_INSTANCE->EVENTS_COMPARE[timer_cc_channel]),
         (m_nrf_fem_control_cfg.pa_cfg.active_high ?
-            (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id]) :
-            (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id])));
+         (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id]) :
+         (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id])));
 }
 
 /**
@@ -258,17 +258,17 @@ void nrf_fem_control_pin_clear(void)
     if (pin_is_enabled(NRF_FEM_CONTROL_PA_PIN))
     {
         nrf_gpiote_task_force(m_nrf_fem_control_cfg.pa_gpiote_ch_id,
-                              (nrf_gpiote_outinit_t)!m_nrf_fem_control_cfg.pa_cfg.active_high);
+                              (nrf_gpiote_outinit_t) !m_nrf_fem_control_cfg.pa_cfg.active_high);
     }
 
     if (pin_is_enabled(NRF_FEM_CONTROL_LNA_PIN))
     {
         nrf_gpiote_task_force(m_nrf_fem_control_cfg.lna_gpiote_ch_id,
-                              (nrf_gpiote_outinit_t)!m_nrf_fem_control_cfg.lna_cfg.active_high);
+                              (nrf_gpiote_outinit_t) !m_nrf_fem_control_cfg.lna_cfg.active_high);
     }
 }
 
-void nrf_fem_control_timer_set(nrf_fem_control_pin_t  pin, 
+void nrf_fem_control_timer_set(nrf_fem_control_pin_t  pin,
                                nrf_timer_cc_channel_t timer_cc_channel,
                                nrf_timer_short_mask_t short_mask)
 {
@@ -333,11 +333,13 @@ void nrf_fem_control_ppi_pin_task_setup(nrf_ppi_channel_t ppi_channel,
         if ((lna_pin_set && m_nrf_fem_control_cfg.lna_cfg.active_high) ||
             (!lna_pin_set && !m_nrf_fem_control_cfg.lna_cfg.active_high))
         {
-            lna_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id]);
+            lna_task_addr =
+                (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.lna_gpiote_ch_id]);
         }
         else
         {
-            lna_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id]);
+            lna_task_addr =
+                (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.lna_gpiote_ch_id]);
         }
     }
 
@@ -346,17 +348,20 @@ void nrf_fem_control_ppi_pin_task_setup(nrf_ppi_channel_t ppi_channel,
         if ((pa_pin_set && m_nrf_fem_control_cfg.pa_cfg.active_high) ||
             (!pa_pin_set && !m_nrf_fem_control_cfg.pa_cfg.active_high))
         {
-            pa_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id]);
+            pa_task_addr =
+                (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_control_cfg.pa_gpiote_ch_id]);
         }
         else
         {
-            pa_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id]);
+            pa_task_addr =
+                (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_control_cfg.pa_gpiote_ch_id]);
         }
     }
 
     if (lna_task_addr != 0 || pa_task_addr != 0)
     {
-        nrf_ppi_channel_and_fork_endpoint_setup(ppi_channel, event_addr, lna_task_addr, pa_task_addr);
+        nrf_ppi_channel_and_fork_endpoint_setup(ppi_channel, event_addr, lna_task_addr,
+                                                pa_task_addr);
         nrf_ppi_channel_enable(ppi_channel);
     }
 }

--- a/src/fem/nrf_fem_control_api.h
+++ b/src/fem/nrf_fem_control_api.h
@@ -51,10 +51,10 @@ extern "C" {
  */
 
 /** Default Power Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_PIN             26
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN             15
 
 /** Default Low Noise Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN            27
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN            16
 
 /** Default PPI channel for pin setting. */
 #define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15

--- a/src/fem/nrf_fem_control_api.h
+++ b/src/fem/nrf_fem_control_api.h
@@ -51,22 +51,22 @@ extern "C" {
  */
 
 /** Default Power Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_PIN                      26
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN             26
 
 /** Default Low Noise Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN                     27
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN            27
 
 /** Default PPI channel for pin setting. */
-#define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL             15
+#define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15
 
 /** Default PPI channel for pin clearing. */
-#define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL             16
+#define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL    16
 
 /** Default GPIOTE channel for FEM control. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL          6
+#define NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL 6
 
 /** Default GPIOTE channel for FEM control. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL           7
+#define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
 
 #if ENABLE_FEM
 
@@ -75,9 +75,9 @@ extern "C" {
  */
 typedef struct
 {
-     uint8_t enable :1;         /**< Enable toggling for this amplifier */
-     uint8_t active_high :1;    /**< Set the pin to be active high */
-     uint8_t gpio_pin :6;       /**< The GPIO pin to toggle for this amplifier */
+    uint8_t enable      : 1; /**< Enable toggling for this amplifier */
+    uint8_t active_high : 1; /**< Set the pin to be active high */
+    uint8_t gpio_pin    : 6; /**< The GPIO pin to toggle for this amplifier */
 } nrf_fem_control_pa_lna_cfg_t;
 
 /**
@@ -94,12 +94,12 @@ typedef struct
  */
 typedef struct
 {
-    nrf_fem_control_pa_lna_cfg_t pa_cfg;            /**< Power Amplifier configuration */
-    nrf_fem_control_pa_lna_cfg_t lna_cfg;           /**< Low Noise Amplifier configuration */
-    uint8_t                      pa_gpiote_ch_id;   /**< GPIOTE channel used for Power Amplifier pin toggling */
-    uint8_t                      lna_gpiote_ch_id;  /**< GPIOTE channel used for Low Noise Amplifier pin toggling */
-    uint8_t                      ppi_ch_id_set;     /**< PPI channel used for radio Power Amplifier and Low Noise Amplifier pins setting */
-    uint8_t                      ppi_ch_id_clr;     /**< PPI channel used for radio pin clearing */
+    nrf_fem_control_pa_lna_cfg_t pa_cfg;           /**< Power Amplifier configuration */
+    nrf_fem_control_pa_lna_cfg_t lna_cfg;          /**< Low Noise Amplifier configuration */
+    uint8_t                      pa_gpiote_ch_id;  /**< GPIOTE channel used for Power Amplifier pin toggling */
+    uint8_t                      lna_gpiote_ch_id; /**< GPIOTE channel used for Low Noise Amplifier pin toggling */
+    uint8_t                      ppi_ch_id_set;    /**< PPI channel used for radio Power Amplifier and Low Noise Amplifier pins setting */
+    uint8_t                      ppi_ch_id_clr;    /**< PPI channel used for radio pin clearing */
 } nrf_fem_control_cfg_t;
 
 /**
@@ -141,7 +141,7 @@ void nrf_fem_control_activate(void);
 void nrf_fem_control_deactivate(void);
 
 /**@brief Configure PPI to activate one of the Front End Module pins on an appropriate timer event.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin to be connected to the PPI.
  * @param[in] timer_cc_channel Timer CC channel that triggers the @p pin activation through the PPI.
  *
@@ -156,9 +156,9 @@ void nrf_fem_control_ppi_enable(nrf_fem_control_pin_t pin, nrf_timer_cc_channel_
 void nrf_fem_control_ppi_disable(nrf_fem_control_pin_t pin);
 
 /**@brief Calculate target time for a timer, which activates one of the Front End Module pins.
- * 
+ *
  * @param[in] pin The Front End Module controlled pin to be activated.
- * 
+ *
  * @return    @p pin activation delay in microseconds.
  *
  */
@@ -170,7 +170,7 @@ uint32_t nrf_fem_control_delay_get(nrf_fem_control_pin_t pin);
 void nrf_fem_control_pin_clear(void);
 
 /**@brief Configure and set a timer for one of the Front End Module pins activation.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin to be activated.
  * @param[in] timer_cc_channel Timer CC channel to set.
  * @param[in] short_mask       Mask of timer shortcuts to be enabled.
@@ -181,7 +181,7 @@ void nrf_fem_control_timer_set(nrf_fem_control_pin_t  pin,
                                nrf_timer_short_mask_t short_mask);
 
 /**@brief Clear timer configuration after one of the Front End Module pins deactivation.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin that was deactivated.
  * @param[in] short_mask       Mask of timer shortcuts to be disabled.
  *
@@ -189,7 +189,7 @@ void nrf_fem_control_timer_set(nrf_fem_control_pin_t  pin,
 void nrf_fem_control_timer_reset(nrf_fem_control_pin_t pin, nrf_timer_short_mask_t short_mask);
 
 /**@brief Setup a PPI fork task necessary for one of the Front End Module pins.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin that was deactivated.
  * @param[in] ppi_channel      PPI channel to connect the fork task to.
  *
@@ -199,7 +199,7 @@ void nrf_fem_control_ppi_fork_setup(nrf_fem_control_pin_t pin,
                                     uint32_t              task_addr);
 
 /**@brief Setup a PPI task necessary for one of the Front End Module pins.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin that was deactivated.
  * @param[in] ppi_channel      PPI channel to connect the task to.
  * @param[in] event_addr       Address of the event to be connected to the PPI.
@@ -212,7 +212,7 @@ void nrf_fem_control_ppi_task_setup(nrf_fem_control_pin_t pin,
                                     uint32_t              task_addr);
 
 /**@brief Clear a PPI fork task configuration for one of the Front End Module pins.
- * 
+ *
  * @param[in] pin              The Front End Module controlled pin that was deactivated.
  * @param[in] ppi_channel      PPI channel to disconnect the fork task from.
  *
@@ -220,7 +220,7 @@ void nrf_fem_control_ppi_task_setup(nrf_fem_control_pin_t pin,
 void nrf_fem_control_ppi_fork_clear(nrf_fem_control_pin_t pin, nrf_ppi_channel_t ppi_channel);
 
 /**@brief Setup PPI task and fork that set or clear Front End Module pins on a given event.
- * 
+ *
  * @param[in] ppi_channel      PPI channel to connect the task and fork to.
  * @param[in] event_addr       Address of the event to be connected to the PPI.
  * @param[in] lna_pin_set      If true, the Low Noise Amplifier pin will be set on the event @p event_addr.
@@ -234,7 +234,7 @@ void nrf_fem_control_ppi_pin_task_setup(nrf_ppi_channel_t ppi_channel,
                                         bool              lna_pin_set,
                                         bool              pa_pin_set);
 
-#else  // ENABLE_FEM
+#else // ENABLE_FEM
 
 #define nrf_fem_control_cfg_set(...)
 #define nrf_fem_control_cfg_get(...)
@@ -242,7 +242,7 @@ void nrf_fem_control_ppi_pin_task_setup(nrf_ppi_channel_t ppi_channel,
 #define nrf_fem_control_deactivate(...)
 #define nrf_fem_control_ppi_enable(...)
 #define nrf_fem_control_ppi_disable(...)
-#define nrf_fem_control_delay_get(...)   1
+#define nrf_fem_control_delay_get(...) 1
 #define nrf_fem_control_pin_clear(...)
 #define nrf_fem_control_timer_set(...)
 #define nrf_fem_control_timer_reset(...)

--- a/src/fem/nrf_fem_control_config.h
+++ b/src/fem/nrf_fem_control_config.h
@@ -40,10 +40,10 @@ extern "C" {
  */
 
 /** Time in us when PA GPIO is activated before radio is ready for transmission. */
-#define NRF_FEM_PA_TIME_IN_ADVANCE          23
+#define NRF_FEM_PA_TIME_IN_ADVANCE  23
 
 /** Time in us when LNA GPIO is activated before radio is ready for reception. */
-#define NRF_FEM_LNA_TIME_IN_ADVANCE         5
+#define NRF_FEM_LNA_TIME_IN_ADVANCE 5
 
 #ifdef NRF52840_XXAA
 

--- a/src/hal/nrf_radio.h
+++ b/src/hal/nrf_radio.h
@@ -57,7 +57,7 @@ extern "C" {
  * @enum nrf_radio_task_t
  * @brief RADIO tasks.
  */
-typedef enum /*lint -save -e30 -esym(628,__INTADDR__) */
+typedef enum                                                              /*lint -save -e30 -esym(628,__INTADDR__) */
 {
     NRF_RADIO_TASK_TXEN      = offsetof(NRF_RADIO_Type, TASKS_TXEN),      /**< Enable radio transmitter. */
     NRF_RADIO_TASK_RXEN      = offsetof(NRF_RADIO_Type, TASKS_RXEN),      /**< Enable radio receiver. */
@@ -75,7 +75,7 @@ typedef enum /*lint -save -e30 -esym(628,__INTADDR__) */
  * @enum nrf_radio_event_t
  * @brief RADIO events.
  */
-typedef enum /*lint -save -e30 -esym(628,__INTADDR__) */
+typedef enum                                                                  /*lint -save -e30 -esym(628,__INTADDR__) */
 {
     NRF_RADIO_EVENT_READY      = offsetof(NRF_RADIO_Type, EVENTS_READY),      /**< Radio has ramped up and is ready to be started. */
     NRF_RADIO_EVENT_ADDRESS    = offsetof(NRF_RADIO_Type, EVENTS_ADDRESS),    /**< Address sent or received. */
@@ -222,8 +222,8 @@ typedef enum
  */
 typedef enum
 {
-    NRF_RADIO_RAMP_UP_MODE_DEFAULT = RADIO_MODECNF0_RU_Default,  /**< Default ramp-up mode. */
-    NRF_RADIO_RAMP_UP_MODE_FAST    = RADIO_MODECNF0_RU_Fast      /**< Fast ramp-up mode. */
+    NRF_RADIO_RAMP_UP_MODE_DEFAULT = RADIO_MODECNF0_RU_Default, /**< Default ramp-up mode. */
+    NRF_RADIO_RAMP_UP_MODE_FAST    = RADIO_MODECNF0_RU_Fast     /**< Fast ramp-up mode. */
 } nrf_radio_ramp_up_mode_t;
 
 /**
@@ -257,7 +257,7 @@ __STATIC_INLINE bool nrf_radio_int_get(nrf_radio_int_mask_t radio_int_mask);
  *
  * @param[in]  radio_task              Task.
  */
-__STATIC_INLINE uint32_t *nrf_radio_task_address_get(nrf_radio_task_t radio_task);
+__STATIC_INLINE uint32_t * nrf_radio_task_address_get(nrf_radio_task_t radio_task);
 
 /**
  * @brief Function for setting a specific task.
@@ -273,7 +273,7 @@ __STATIC_INLINE void nrf_radio_task_trigger(nrf_radio_task_t radio_task);
  *
  * @param[in]  radio_event              Event.
  */
-__STATIC_INLINE uint32_t *nrf_radio_event_address_get(nrf_radio_event_t radio_event);
+__STATIC_INLINE uint32_t * nrf_radio_event_address_get(nrf_radio_event_t radio_event);
 
 /**
  * @brief Function for clearing a specific event.
@@ -334,7 +334,7 @@ __STATIC_INLINE nrf_radio_state_t nrf_radio_state_get(void);
  *
  * @param[in]  p_radio_packet_ptr           Pointer to tx or rx packet buffer.
  */
-__STATIC_INLINE void nrf_radio_packet_ptr_set(const void *p_radio_packet_ptr);
+__STATIC_INLINE void nrf_radio_packet_ptr_set(const void * p_radio_packet_ptr);
 
 /**
  * @brief Function for getting CRC status of last received packet.
@@ -532,7 +532,6 @@ __STATIC_INLINE void nrf_radio_ed_loop_count_set(uint32_t radio_ed_loop_count);
  */
 __STATIC_INLINE void nrf_radio_power_set(bool radio_power);
 
-
 /**
  *@}
  **/
@@ -554,7 +553,7 @@ __STATIC_INLINE bool nrf_radio_int_get(nrf_radio_int_mask_t radio_int_mask)
     return (bool)(NRF_RADIO->INTENCLR & radio_int_mask);
 }
 
-__STATIC_INLINE uint32_t *nrf_radio_task_address_get(nrf_radio_task_t radio_task)
+__STATIC_INLINE uint32_t * nrf_radio_task_address_get(nrf_radio_task_t radio_task)
 {
     return (uint32_t *)((uint8_t *)NRF_RADIO + radio_task);
 }
@@ -564,7 +563,7 @@ __STATIC_INLINE void nrf_radio_task_trigger(nrf_radio_task_t radio_task)
     *((volatile uint32_t *)((uint8_t *)NRF_RADIO + radio_task)) = NRF_RADIO_TASK_SET;
 }
 
-__STATIC_INLINE uint32_t *nrf_radio_event_address_get(nrf_radio_event_t radio_event)
+__STATIC_INLINE uint32_t * nrf_radio_event_address_get(nrf_radio_event_t radio_event)
 {
     return (uint32_t *)((uint8_t *)NRF_RADIO + radio_event);
 }
@@ -580,7 +579,7 @@ __STATIC_INLINE void nrf_radio_event_clear(nrf_radio_event_t radio_event)
 
 __STATIC_INLINE bool nrf_radio_event_get(nrf_radio_event_t radio_event)
 {
-    return (bool) * ((volatile uint32_t *)((uint8_t *)NRF_RADIO + radio_event));
+    return (bool)*((volatile uint32_t *)((uint8_t *)NRF_RADIO + radio_event));
 }
 
 __STATIC_INLINE void nrf_radio_shorts_enable(uint32_t radio_short_mask)
@@ -605,84 +604,85 @@ __STATIC_INLINE uint32_t nrf_radio_shorts_get(void)
 
 __STATIC_INLINE nrf_radio_state_t nrf_radio_state_get(void)
 {
-    return (nrf_radio_state_t) NRF_RADIO->STATE;
+    return (nrf_radio_state_t)NRF_RADIO->STATE;
 }
 
-__STATIC_INLINE void nrf_radio_packet_ptr_set(const void *p_radio_packet_ptr)
+__STATIC_INLINE void nrf_radio_packet_ptr_set(const void * p_radio_packet_ptr)
 {
-    NRF_RADIO->PACKETPTR = (uint32_t) p_radio_packet_ptr;
+    NRF_RADIO->PACKETPTR = (uint32_t)p_radio_packet_ptr;
 }
 
 __STATIC_INLINE nrf_radio_crc_status_t nrf_radio_crc_status_get(void)
 {
-    return (nrf_radio_crc_status_t) NRF_RADIO->CRCSTATUS;
+    return (nrf_radio_crc_status_t)NRF_RADIO->CRCSTATUS;
 }
 
 __STATIC_INLINE void nrf_radio_cca_mode_set(nrf_radio_cca_mode_t radio_cca_mode)
 {
     NRF_RADIO->CCACTRL &= (~RADIO_CCACTRL_CCAMODE_Msk);
-    NRF_RADIO->CCACTRL |= ((uint32_t) radio_cca_mode << RADIO_CCACTRL_CCAMODE_Pos);
+    NRF_RADIO->CCACTRL |= ((uint32_t)radio_cca_mode << RADIO_CCACTRL_CCAMODE_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_cca_ed_threshold_set(uint8_t radio_cca_ed_threshold)
 {
     NRF_RADIO->CCACTRL &= (~RADIO_CCACTRL_CCAEDTHRES_Msk);
-    NRF_RADIO->CCACTRL |= ((uint32_t) radio_cca_ed_threshold << RADIO_CCACTRL_CCAEDTHRES_Pos);
+    NRF_RADIO->CCACTRL |= ((uint32_t)radio_cca_ed_threshold << RADIO_CCACTRL_CCAEDTHRES_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_cca_corr_threshold_set(uint8_t radio_cca_corr_threshold_set)
 {
     NRF_RADIO->CCACTRL &= (~RADIO_CCACTRL_CCACORRTHRES_Msk);
-    NRF_RADIO->CCACTRL |= ((uint32_t) radio_cca_corr_threshold_set << RADIO_CCACTRL_CCACORRTHRES_Pos);
+    NRF_RADIO->CCACTRL |=
+        ((uint32_t)radio_cca_corr_threshold_set << RADIO_CCACTRL_CCACORRTHRES_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_cca_corr_counter_set(uint8_t radio_cca_corr_counter_set)
 {
     NRF_RADIO->CCACTRL &= (~RADIO_CCACTRL_CCACORRCNT_Msk);
-    NRF_RADIO->CCACTRL |= ((uint32_t) radio_cca_corr_counter_set << RADIO_CCACTRL_CCACORRCNT_Pos);
+    NRF_RADIO->CCACTRL |= ((uint32_t)radio_cca_corr_counter_set << RADIO_CCACTRL_CCACORRCNT_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_mode_set(nrf_radio_mode_t radio_mode)
 {
-    NRF_RADIO->MODE = ((uint32_t) radio_mode << RADIO_MODE_MODE_Pos);
+    NRF_RADIO->MODE = ((uint32_t)radio_mode << RADIO_MODE_MODE_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_config_length_field_length_set(uint8_t radio_length_length)
 {
     NRF_RADIO->PCNF0 &= (~RADIO_PCNF0_LFLEN_Msk);
-    NRF_RADIO->PCNF0 |= ((uint32_t) radio_length_length << RADIO_PCNF0_LFLEN_Pos);
+    NRF_RADIO->PCNF0 |= ((uint32_t)radio_length_length << RADIO_PCNF0_LFLEN_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_config_preamble_length_set(
     nrf_radio_preamble_length_t radio_preamble_length)
 {
     NRF_RADIO->PCNF0 &= (~RADIO_PCNF0_PLEN_Msk);
-    NRF_RADIO->PCNF0 |= ((uint32_t) radio_preamble_length << RADIO_PCNF0_PLEN_Pos);
+    NRF_RADIO->PCNF0 |= ((uint32_t)radio_preamble_length << RADIO_PCNF0_PLEN_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_config_crc_included_set(bool radio_length_contains_crc)
 {
     NRF_RADIO->PCNF0 &= (~RADIO_PCNF0_CRCINC_Msk);
-    NRF_RADIO->PCNF0 |= ((uint32_t) radio_length_contains_crc << RADIO_PCNF0_CRCINC_Pos);
+    NRF_RADIO->PCNF0 |= ((uint32_t)radio_length_contains_crc << RADIO_PCNF0_CRCINC_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_config_max_length_set(uint8_t radio_max_packet_length)
 {
     NRF_RADIO->PCNF1 &= (~RADIO_PCNF1_MAXLEN_Msk);
-    NRF_RADIO->PCNF1 |= ((uint32_t) radio_max_packet_length << RADIO_PCNF1_MAXLEN_Pos);
+    NRF_RADIO->PCNF1 |= ((uint32_t)radio_max_packet_length << RADIO_PCNF1_MAXLEN_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_crc_length_set(uint8_t radio_crc_length)
 {
     NRF_RADIO->CRCCNF &= (~RADIO_CRCCNF_LEN_Msk);
-    NRF_RADIO->CRCCNF |= ((uint32_t) radio_crc_length << RADIO_CRCCNF_LEN_Pos);
+    NRF_RADIO->CRCCNF |= ((uint32_t)radio_crc_length << RADIO_CRCCNF_LEN_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_crc_includes_address_set(
     nrf_radio_crc_includes_addr_t radio_crc_skip_address)
 {
     NRF_RADIO->CRCCNF &= (~RADIO_CRCCNF_SKIPADDR_Msk);
-    NRF_RADIO->CRCCNF |= ((uint32_t) radio_crc_skip_address << RADIO_CRCCNF_SKIPADDR_Pos);
+    NRF_RADIO->CRCCNF |= ((uint32_t)radio_crc_skip_address << RADIO_CRCCNF_SKIPADDR_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_crc_polynominal_set(uint32_t radio_crc_polynominal)
@@ -714,7 +714,7 @@ __STATIC_INLINE void nrf_radio_mhmu_pattern_mask_set(uint32_t radio_mhmu_pattern
 __STATIC_INLINE void nrf_radio_ramp_up_mode_set(nrf_radio_ramp_up_mode_t ramp_up_mode)
 {
     NRF_RADIO->MODECNF0 &= (~RADIO_MODECNF0_RU_Msk);
-    NRF_RADIO->MODECNF0 |= ((uint32_t) ramp_up_mode << RADIO_MODECNF0_RU_Pos);
+    NRF_RADIO->MODECNF0 |= ((uint32_t)ramp_up_mode << RADIO_MODECNF0_RU_Pos);
 }
 
 __STATIC_INLINE void nrf_radio_frequency_set(uint32_t radio_frequency)
@@ -729,7 +729,7 @@ __STATIC_INLINE uint32_t nrf_radio_frequency_get(void)
 
 __STATIC_INLINE void nrf_radio_tx_power_set(int8_t radio_tx_power)
 {
-    NRF_RADIO->TXPOWER = (uint8_t) radio_tx_power;
+    NRF_RADIO->TXPOWER = (uint8_t)radio_tx_power;
 }
 
 __STATIC_INLINE void nrf_radio_ifs_set(uint32_t radio_ifs)
@@ -754,7 +754,7 @@ __STATIC_INLINE uint32_t nrf_radio_bcc_get(void)
 
 __STATIC_INLINE uint8_t nrf_radio_ed_sample_get(void)
 {
-    return (uint8_t) NRF_RADIO->EDSAMPLE;
+    return (uint8_t)NRF_RADIO->EDSAMPLE;
 }
 
 __STATIC_INLINE void nrf_radio_ed_loop_count_set(uint32_t radio_ed_loop_count)
@@ -764,7 +764,7 @@ __STATIC_INLINE void nrf_radio_ed_loop_count_set(uint32_t radio_ed_loop_count)
 
 __STATIC_INLINE void nrf_radio_power_set(bool radio_power)
 {
-    NRF_RADIO->POWER = (uint32_t) radio_power;
+    NRF_RADIO->POWER = (uint32_t)radio_power;
 }
 
 #endif /* SUPPRESS_INLINE_IMPLEMENTATION */
@@ -774,4 +774,3 @@ __STATIC_INLINE void nrf_radio_power_set(bool radio_power)
 #endif
 
 #endif /* NRF_RADIO_H__ */
-

--- a/src/hal/nrf_radio.h
+++ b/src/hal/nrf_radio.h
@@ -57,7 +57,8 @@ extern "C" {
  * @enum nrf_radio_task_t
  * @brief RADIO tasks.
  */
-typedef enum                                                              /*lint -save -e30 -esym(628,__INTADDR__) */
+/*lint -save -e30 -esym(628,__INTADDR__) */
+typedef enum
 {
     NRF_RADIO_TASK_TXEN      = offsetof(NRF_RADIO_Type, TASKS_TXEN),      /**< Enable radio transmitter. */
     NRF_RADIO_TASK_RXEN      = offsetof(NRF_RADIO_Type, TASKS_RXEN),      /**< Enable radio receiver. */
@@ -69,13 +70,13 @@ typedef enum                                                              /*lint
     NRF_RADIO_TASK_EDSTART   = offsetof(NRF_RADIO_Type, TASKS_EDSTART),   /**< Start Energy Detection procedure. */
     NRF_RADIO_TASK_EDSTOP    = offsetof(NRF_RADIO_Type, TASKS_EDSTOP),    /**< Stop Energy Detection procedure. */
     NRF_RADIO_TASK_RSSISTART = offsetof(NRF_RADIO_Type, TASKS_RSSISTART), /**< Start the RSSI and take one single sample of received signal strength. */
-} nrf_radio_task_t;                                                       /*lint -restore */
+} nrf_radio_task_t;
 
 /**
  * @enum nrf_radio_event_t
  * @brief RADIO events.
  */
-typedef enum                                                                  /*lint -save -e30 -esym(628,__INTADDR__) */
+typedef enum
 {
     NRF_RADIO_EVENT_READY      = offsetof(NRF_RADIO_Type, EVENTS_READY),      /**< Radio has ramped up and is ready to be started. */
     NRF_RADIO_EVENT_ADDRESS    = offsetof(NRF_RADIO_Type, EVENTS_ADDRESS),    /**< Address sent or received. */
@@ -93,7 +94,8 @@ typedef enum                                                                  /*
     NRF_RADIO_EVENT_RXREADY    = offsetof(NRF_RADIO_Type, EVENTS_RXREADY),    /**< Radio has ramped up and is ready to be started RX path. */
     NRF_RADIO_EVENT_MHRMATCH   = offsetof(NRF_RADIO_Type, EVENTS_MHRMATCH),   /**< MAC Header match found. */
     NRF_RADIO_EVENT_PHYEND     = offsetof(NRF_RADIO_Type, EVENTS_PHYEND),     /**< Generated in Ble_LR125Kbit, Ble_LR500Kbit and Ieee802154_250Kbit modes when last bit is sent on air. */
-} nrf_radio_event_t;                                                          /*lint -restore */
+} nrf_radio_event_t;
+/*lint -restore */
 
 /**
  * @enum nrf_radio_int_mask_t
@@ -573,6 +575,7 @@ __STATIC_INLINE void nrf_radio_event_clear(nrf_radio_event_t radio_event)
     *((volatile uint32_t *)((uint8_t *)NRF_RADIO + radio_event)) = NRF_RADIO_EVENT_CLEAR;
 #if __CORTEX_M == 0x04
     volatile uint32_t dummy = *((volatile uint32_t *)((uint8_t *)NRF_RADIO + radio_event));
+
     (void)dummy;
 #endif
 }

--- a/src/mac_features/nrf_802154_ack_timeout.c
+++ b/src/mac_features/nrf_802154_ack_timeout.c
@@ -44,13 +44,13 @@
 #include "nrf_802154_request.h"
 #include "timer_scheduler/nrf_802154_timer_sched.h"
 
-#define RETRY_DELAY     500      ///< Procedure is delayed by this time if cannot be performed at the moment.
-#define MAX_RETRY_DELAY 1000000  ///< Maximal allowed delay of procedure retry.
+#define RETRY_DELAY     500     ///< Procedure is delayed by this time if cannot be performed at the moment.
+#define MAX_RETRY_DELAY 1000000 ///< Maximal allowed delay of procedure retry.
 
 static void timeout_timer_retry(void);
 
-static uint32_t           m_timeout = NRF_802154_ACK_TIMEOUT_DEFAULT_TIMEOUT;  ///< ACK timeout in us.
-static nrf_802154_timer_t m_timer;                                             ///< Timer used to notify when we are waiting too long for ACK.
+static uint32_t           m_timeout = NRF_802154_ACK_TIMEOUT_DEFAULT_TIMEOUT; ///< ACK timeout in us.
+static nrf_802154_timer_t m_timer;                                            ///< Timer used to notify when we are waiting too long for ACK.
 static volatile bool      m_procedure_is_active;
 static const uint8_t    * mp_frame;
 

--- a/src/mac_features/nrf_802154_ack_timeout.h
+++ b/src/mac_features/nrf_802154_ack_timeout.h
@@ -46,7 +46,7 @@
 
 /**
  * @brief Set timeout time for ACK timeout feature.
- * 
+ *
  * @param[in]  time  Timeout time in us.
  *                   Default value is defined in nrf_802154_config.h.
  */
@@ -82,7 +82,6 @@ void nrf_802154_ack_timeout_transmitted_hook(const uint8_t * p_frame);
  *                 internally.
  */
 bool nrf_802154_ack_timeout_tx_failed_hook(const uint8_t * p_frame, nrf_802154_tx_error_t error);
-
 
 /**
  * @brief Handler of TX started event.

--- a/src/mac_features/nrf_802154_csma_ca.c
+++ b/src/mac_features/nrf_802154_csma_ca.c
@@ -50,12 +50,12 @@
 
 #if NRF_802154_CSMA_CA_ENABLED
 
-static uint8_t m_nb;  ///< The number of times the CSMA-CA algorithm was required to back off while attempting the current transmission.
-static uint8_t m_be;  ///< Backoff exponent, which is related to how many backoff periods a device shall wait before attempting to assess a channel.
+static uint8_t m_nb;                    ///< The number of times the CSMA-CA algorithm was required to back off while attempting the current transmission.
+static uint8_t m_be;                    ///< Backoff exponent, which is related to how many backoff periods a device shall wait before attempting to assess a channel.
 
-static const uint8_t    * mp_psdu;       ///< Pointer to PSDU of the frame being transmitted.
-static nrf_802154_timer_t m_timer;       ///< Timer used to back off during CSMA-CA procedure.
-static bool               m_is_running;  ///< Indicates if CSMA-CA procedure is running.
+static const uint8_t    * mp_psdu;      ///< Pointer to PSDU of the frame being transmitted.
+static nrf_802154_timer_t m_timer;      ///< Timer used to back off during CSMA-CA procedure.
+static bool               m_is_running; ///< Indicates if CSMA-CA procedure is running.
 
 /**
  * @brief Perform appropriate actions for busy channel conditions.

--- a/src/mac_features/nrf_802154_delayed_trx.c
+++ b/src/mac_features/nrf_802154_delayed_trx.c
@@ -48,11 +48,11 @@
 #include "nrf_802154_request.h"
 #include "nrf_802154_rsch.h"
 
-#define TX_SETUP_TIME 190  ///< Time [us] needed to change channel, stop rx and setup tx procedure.
+#define TX_SETUP_TIME 190            ///< Time [us] needed to change channel, stop rx and setup tx procedure.
 
-static const uint8_t * mp_tx_psdu;    ///< Pointer to PHR + PSDU of the frame requested to transmit.
-static bool            m_tx_cca;      ///< If CCA should be performed prior to transmission.
-static uint8_t         m_tx_channel;  ///< Channel number on which transmission should be performed.
+static const uint8_t * mp_tx_psdu;   ///< Pointer to PHR + PSDU of the frame requested to transmit.
+static bool            m_tx_cca;     ///< If CCA should be performed prior to transmission.
+static uint8_t         m_tx_channel; ///< Channel number on which transmission should be performed.
 
 /**
  * Check if delayed transmission procedure is in progress.

--- a/src/mac_features/nrf_802154_filter.c
+++ b/src/mac_features/nrf_802154_filter.c
@@ -153,12 +153,12 @@ static nrf_802154_rx_error_t dst_addressing_end_offset_get_2006(const uint8_t * 
     {
         case DEST_ADDR_TYPE_SHORT:
             *p_num_bytes = SHORT_ADDR_CHECK_OFFSET;
-            result = NRF_802154_RX_ERROR_NONE;
+            result       = NRF_802154_RX_ERROR_NONE;
             break;
 
         case DEST_ADDR_TYPE_EXTENDED:
             *p_num_bytes = EXTENDED_ADDR_CHECK_OFFSET;
-            result = NRF_802154_RX_ERROR_NONE;
+            result       = NRF_802154_RX_ERROR_NONE;
             break;
 
         case DEST_ADDR_TYPE_NONE:
@@ -168,12 +168,12 @@ static nrf_802154_rx_error_t dst_addressing_end_offset_get_2006(const uint8_t * 
                 {
                     case SRC_ADDR_TYPE_SHORT:
                         *p_num_bytes = SHORT_ADDR_CHECK_OFFSET;
-                        result = NRF_802154_RX_ERROR_NONE;
+                        result       = NRF_802154_RX_ERROR_NONE;
                         break;
 
                     case SRC_ADDR_TYPE_EXTENDED:
                         *p_num_bytes = EXTENDED_ADDR_CHECK_OFFSET;
-                        result = NRF_802154_RX_ERROR_NONE;
+                        result       = NRF_802154_RX_ERROR_NONE;
                         break;
 
                     default:
@@ -363,7 +363,7 @@ static bool dst_short_addr_check(const uint8_t * p_psdu)
  * @retval true   Destination address of incoming frame allows further processing of the frame.
  * @retval false  Destination address of incoming frame does not allow further processing.
  */
-static bool dst_extended_addr_check(const uint8_t *p_psdu)
+static bool dst_extended_addr_check(const uint8_t * p_psdu)
 {
     bool result;
 
@@ -432,7 +432,7 @@ nrf_802154_rx_error_t nrf_802154_filter_frame_part(const uint8_t * p_psdu, uint8
             }
 
             result = dst_short_addr_check(p_psdu) ? NRF_802154_RX_ERROR_NONE :
-                    NRF_802154_RX_ERROR_INVALID_DEST_ADDR;
+                     NRF_802154_RX_ERROR_INVALID_DEST_ADDR;
             break;
 
         case EXTENDED_ADDR_CHECK_OFFSET:
@@ -443,7 +443,7 @@ nrf_802154_rx_error_t nrf_802154_filter_frame_part(const uint8_t * p_psdu, uint8
             }
 
             result = dst_extended_addr_check(p_psdu) ? NRF_802154_RX_ERROR_NONE :
-                    NRF_802154_RX_ERROR_INVALID_DEST_ADDR;
+                     NRF_802154_RX_ERROR_INVALID_DEST_ADDR;
             break;
 
         default:

--- a/src/mac_features/nrf_802154_filter.h
+++ b/src/mac_features/nrf_802154_filter.h
@@ -48,7 +48,6 @@
  * @brief Procedures used to discard incoming frames that contain unexpected data in PHR or MHR.
  */
 
-
 /**
  * @brief Verify if given part of the frame is valid.
  *
@@ -75,4 +74,3 @@
 nrf_802154_rx_error_t nrf_802154_filter_frame_part(const uint8_t * p_psdu, uint8_t * p_num_bytes);
 
 #endif /* NRF_802154_FILTER_H_ */
-

--- a/src/mac_features/nrf_802154_precise_ack_timeout.c
+++ b/src/mac_features/nrf_802154_precise_ack_timeout.c
@@ -45,13 +45,13 @@
 #include "nrf_802154_request.h"
 #include "timer_scheduler/nrf_802154_timer_sched.h"
 
-#define RETRY_DELAY     500      ///< Procedure is delayed by this time if it cannot be performed at the moment [us].
-#define MAX_RETRY_DELAY 1000000  ///< Maximum allowed delay of procedure retry [us].
+#define RETRY_DELAY     500     ///< Procedure is delayed by this time if it cannot be performed at the moment [us].
+#define MAX_RETRY_DELAY 1000000 ///< Maximum allowed delay of procedure retry [us].
 
 static void timeout_timer_retry(void);
 
-static uint32_t           m_timeout = NRF_802154_PRECISE_ACK_TIMEOUT_DEFAULT_TIMEOUT;  ///< ACK timeout in us.
-static nrf_802154_timer_t m_timer;                                                     ///< Timer used to notify when the ACK frama is not received for too long.
+static uint32_t           m_timeout = NRF_802154_PRECISE_ACK_TIMEOUT_DEFAULT_TIMEOUT; ///< ACK timeout in us.
+static nrf_802154_timer_t m_timer;                                                    ///< Timer used to notify when the ACK frama is not received for too long.
 static volatile bool      m_procedure_is_active;
 static const uint8_t    * mp_frame;
 

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -485,11 +485,11 @@ bool nrf_802154_buffer_free_immediately(uint8_t * p_data)
 
 int8_t nrf_802154_rssi_last_get(void)
 {
-    uint8_t minus_dbm = nrf_radio_rssi_sample_get();
+    uint8_t negative_dbm = nrf_radio_rssi_sample_get();
 
-    minus_dbm = nrf_802154_rssi_sample_corrected_get(minus_dbm);
+    negative_dbm = nrf_802154_rssi_sample_corrected_get(negative_dbm);
 
-    return -(int8_t)minus_dbm;
+    return -(int8_t)negative_dbm;
 }
 
 bool nrf_802154_promiscuous_get(void)

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -97,6 +97,7 @@ static void tx_buffer_fill(const uint8_t * p_data, uint8_t length)
     m_tx_buffer[RAW_LENGTH_OFFSET] = length + FCS_SIZE;
     memcpy(&m_tx_buffer[RAW_PAYLOAD_OFFSET], p_data, length);
 }
+
 #endif // !NRF_802154_USE_RAW_API
 
 /**
@@ -129,7 +130,7 @@ static uint32_t last_rx_frame_timestamp_get(void)
     return timestamp;
 #else // NRF_802154_FRAME_TIMESTAMP_ENABLED
     return NRF_802154_NO_TIMESTAMP;
-#endif // NRF_802154_FRAME_TIMESTAMP_ENABLED
+#endif  // NRF_802154_FRAME_TIMESTAMP_ENABLED
 }
 
 void nrf_802154_channel_set(uint8_t channel)
@@ -192,6 +193,7 @@ uint8_t nrf_802154_ccaedthres_from_dbm_calculate(int8_t dbm)
 uint32_t nrf_802154_first_symbol_timestamp_get(uint32_t end_timestamp, uint8_t psdu_length)
 {
     uint32_t frame_symbols = PHY_SHR_SYMBOLS;
+
     frame_symbols += (PHR_SIZE + psdu_length) * PHY_SYMBOLS_PER_OCTET;
 
     return end_timestamp - (frame_symbols * PHY_US_PER_SYMBOL);
@@ -233,6 +235,7 @@ void nrf_802154_radio_irq_handler(void)
 {
     nrf_802154_core_irq_handler();
 }
+
 #endif // !NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 
 #if ENABLE_FEM
@@ -245,33 +248,34 @@ void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg)
 {
     nrf_fem_control_cfg_get(p_cfg);
 }
+
 #endif // ENABLE_FEM
 
 nrf_802154_state_t nrf_802154_state_get(void)
 {
     switch (nrf_802154_core_state_get())
     {
-    case RADIO_STATE_SLEEP:
-    case RADIO_STATE_FALLING_ASLEEP:
-        return NRF_802154_STATE_SLEEP;
+        case RADIO_STATE_SLEEP:
+        case RADIO_STATE_FALLING_ASLEEP:
+            return NRF_802154_STATE_SLEEP;
 
-    case RADIO_STATE_RX:
-    case RADIO_STATE_TX_ACK:
-        return NRF_802154_STATE_RECEIVE;
+        case RADIO_STATE_RX:
+        case RADIO_STATE_TX_ACK:
+            return NRF_802154_STATE_RECEIVE;
 
-    case RADIO_STATE_CCA_TX:
-    case RADIO_STATE_TX:
-    case RADIO_STATE_RX_ACK:
-        return NRF_802154_STATE_TRANSMIT;
+        case RADIO_STATE_CCA_TX:
+        case RADIO_STATE_TX:
+        case RADIO_STATE_RX_ACK:
+            return NRF_802154_STATE_TRANSMIT;
 
-    case RADIO_STATE_ED:
-        return NRF_802154_STATE_ENERGY_DETECTION;
+        case RADIO_STATE_ED:
+            return NRF_802154_STATE_ENERGY_DETECTION;
 
-    case RADIO_STATE_CCA:
-        return NRF_802154_STATE_CCA;
+        case RADIO_STATE_CCA:
+            return NRF_802154_STATE_CCA;
 
-    case RADIO_STATE_CONTINUOUS_CARRIER:
-        return NRF_802154_STATE_CONTINUOUS_CARRIER;
+        case RADIO_STATE_CONTINUOUS_CARRIER:
+            return NRF_802154_STATE_CONTINUOUS_CARRIER;
     }
 
     return NRF_802154_STATE_INVALID;
@@ -280,6 +284,7 @@ nrf_802154_state_t nrf_802154_state_get(void)
 bool nrf_802154_sleep(void)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_SLEEP);
 
     result = nrf_802154_request_sleep(NRF_802154_TERM_802154);
@@ -291,10 +296,13 @@ bool nrf_802154_sleep(void)
 nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void)
 {
     nrf_802154_sleep_error_t result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_SLEEP);
-    
-    result = nrf_802154_request_sleep(NRF_802154_TERM_NONE) ? NRF_802154_SLEEP_ERROR_NONE : NRF_802154_SLEEP_ERROR_BUSY;
-    
+
+    result =
+        nrf_802154_request_sleep(NRF_802154_TERM_NONE) ? NRF_802154_SLEEP_ERROR_NONE :
+        NRF_802154_SLEEP_ERROR_BUSY;
+
     nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_SLEEP);
     return result;
 }
@@ -302,6 +310,7 @@ nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void)
 bool nrf_802154_receive(void)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_RECEIVE);
 
     result = nrf_802154_request_receive(NRF_802154_TERM_802154, REQ_ORIG_HIGHER_LAYER, NULL, true);
@@ -314,6 +323,7 @@ bool nrf_802154_receive(void)
 bool nrf_802154_transmit_raw(const uint8_t * p_data, bool cca)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_TRANSMIT);
 
     result = nrf_802154_request_transmit(NRF_802154_TERM_NONE,
@@ -332,6 +342,7 @@ bool nrf_802154_transmit_raw(const uint8_t * p_data, bool cca)
 bool nrf_802154_transmit(const uint8_t * p_data, uint8_t length, bool cca)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_TRANSMIT);
 
     tx_buffer_fill(p_data, length);
@@ -355,6 +366,7 @@ bool nrf_802154_transmit_raw_at(const uint8_t * p_data,
                                 uint8_t         channel)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_TRANSMIT_AT);
 
     result = nrf_802154_delayed_trx_transmit(p_data, cca, t0, dt, channel);
@@ -366,6 +378,7 @@ bool nrf_802154_transmit_raw_at(const uint8_t * p_data,
 bool nrf_802154_energy_detection(uint32_t time_us)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_ENERGY_DETECTION);
 
     result = nrf_802154_request_energy_detection(NRF_802154_TERM_NONE, time_us);
@@ -377,6 +390,7 @@ bool nrf_802154_energy_detection(uint32_t time_us)
 bool nrf_802154_cca(void)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_CCA);
 
     result = nrf_802154_request_cca(NRF_802154_TERM_NONE);
@@ -388,6 +402,7 @@ bool nrf_802154_cca(void)
 bool nrf_802154_continuous_carrier(void)
 {
     bool result;
+
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_CONTINUOUS_CARRIER);
 
     result = nrf_802154_request_continuous_carrier(NRF_802154_TERM_NONE);
@@ -474,7 +489,7 @@ int8_t nrf_802154_rssi_last_get(void)
 
     minus_dbm = nrf_802154_rssi_sample_corrected_get(minus_dbm);
 
-    return - (int8_t)minus_dbm;
+    return -(int8_t)minus_dbm;
 }
 
 bool nrf_802154_promiscuous_get(void)
@@ -619,6 +634,7 @@ __WEAK void nrf_802154_received_timestamp(uint8_t * p_data,
 
     nrf_802154_buffer_free(p_data);
 }
+
 #endif // !NRF_802154_USE_RAW_API
 
 __WEAK void nrf_802154_receive_failed(nrf_802154_rx_error_t error)
@@ -690,8 +706,8 @@ __WEAK void nrf_802154_transmitted_timestamp(const uint8_t * p_frame,
         nrf_802154_buffer_free(p_ack);
     }
 }
-#endif // NRF_802154_USE_RAW_API
 
+#endif // NRF_802154_USE_RAW_API
 
 __WEAK void nrf_802154_transmit_failed(const uint8_t * p_frame, nrf_802154_tx_error_t error)
 {

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -128,22 +128,22 @@ int8_t nrf_802154_tx_power_get(void);
 typedef nrf_fem_control_cfg_t nrf_802154_fem_control_cfg_t;
 
 /** Macro with default configuration of the FEM module. */
-#define NRF_802154_FEM_DEFAULT_SETTINGS                                                            \
-    ((nrf_802154_fem_control_cfg_t) {                                                              \
-        .pa_cfg = {                                                                                \
-                .enable      = 1,                                                                  \
-                .active_high = 1,                                                                  \
-                .gpio_pin    = NRF_FEM_CONTROL_DEFAULT_PA_PIN,                                     \
-        },                                                                                         \
-        .lna_cfg = {                                                                               \
-                .enable      = 1,                                                                  \
-                .active_high = 1,                                                                  \
-                .gpio_pin    = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,                                    \
-        },                                                                                         \
-        .pa_gpiote_ch_id   = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL,                            \
-        .lna_gpiote_ch_id  = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL,                           \
-        .ppi_ch_id_set     = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,                              \
-        .ppi_ch_id_clr     = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,                              \
+#define NRF_802154_FEM_DEFAULT_SETTINGS                                 \
+    ((nrf_802154_fem_control_cfg_t) {                                   \
+        .pa_cfg = {                                                     \
+            .enable = 1,                                                \
+            .active_high = 1,                                           \
+            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,                 \
+        },                                                              \
+        .lna_cfg = {                                                    \
+            .enable = 1,                                                \
+            .active_high = 1,                                           \
+            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,                \
+        },                                                              \
+        .pa_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL,   \
+        .lna_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL, \
+        .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,       \
+        .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,       \
     })
 
 /**
@@ -166,9 +166,8 @@ void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg);
 
 #endif // ENABLE_FEM
 
-
 /**
- * @} 
+ * @}
  * @defgroup nrf_802154_addresses Setting addresses and PAN ID of the device
  * @{
  */
@@ -180,7 +179,7 @@ void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg);
  *
  * This function makes a copy of the PAN ID.
  */
-void nrf_802154_pan_id_set(const uint8_t *p_pan_id);
+void nrf_802154_pan_id_set(const uint8_t * p_pan_id);
 
 /**
  * @brief Set the extended address of the device.
@@ -189,7 +188,7 @@ void nrf_802154_pan_id_set(const uint8_t *p_pan_id);
  *
  * This function makes a copy of the address.
  */
-void nrf_802154_extended_address_set(const uint8_t *p_extended_address);
+void nrf_802154_extended_address_set(const uint8_t * p_extended_address);
 
 /**
  * @brief Set the short address of the device.
@@ -198,8 +197,7 @@ void nrf_802154_extended_address_set(const uint8_t *p_extended_address);
  *
  * This function makes a copy of the address.
  */
-void nrf_802154_short_address_set(const uint8_t *p_short_address);
-
+void nrf_802154_short_address_set(const uint8_t * p_short_address);
 
 /**
  * @}
@@ -235,7 +233,6 @@ uint8_t nrf_802154_ccaedthres_from_dbm_calculate(int8_t dbm);
  * @return  Timestamp of the beginning of the first preamble symbol of a given frame (in us).
  */
 uint32_t nrf_802154_first_symbol_timestamp_get(uint32_t end_timestamp, uint8_t psdu_length);
-
 
 /**
  * @}
@@ -294,7 +291,7 @@ bool nrf_802154_receive(void);
 /**
  * @brief Change radio state to transmit.
  *
- * @note If the CPU is halted or interrupted while this function is executed, 
+ * @note If the CPU is halted or interrupted while this function is executed,
  *       @ref nrf_802154_transmitted or @ref nrf_802154_transmit_failed may be called before this
  *       function returns a result.
  * @note This function is implemented in zero-copy fashion. It passes the given buffer pointer to
@@ -334,7 +331,7 @@ bool nrf_802154_transmit_raw(const uint8_t * p_data, bool cca);
 /**
  * @brief Change radio state to transmit.
  *
- * @note If the CPU is halted or interrupted while this function is executed, 
+ * @note If the CPU is halted or interrupted while this function is executed,
  *       @ref nrf_802154_transmitted or @ref nrf_802154_transmit_failed must be called before this
  *       function returns a result.
  * @note This function copies the given buffer. It maintains an internal buffer, which is used to
@@ -454,7 +451,6 @@ bool nrf_802154_cca(void);
  * @retval  false  If the driver could not schedule the continuous carrier procedure.
  */
 bool nrf_802154_continuous_carrier(void);
-
 
 /**
  * @}
@@ -586,7 +582,7 @@ extern void nrf_802154_receive_failed(nrf_802154_rx_error_t error);
  * @brief Notify that transmitting a frame has started.
  *
  * @note Usually, @ref nrf_802154_transmitted is called shortly after this function.
- *       However, if the transmit procedure is interrupted, it might happen that 
+ *       However, if the transmit procedure is interrupted, it might happen that
  *       @ref nrf_802154_transmitted is not called.
  * @note This function should be very short to prevent dropping frames by the driver.
  *
@@ -694,7 +690,7 @@ extern void nrf_802154_transmitted(const uint8_t * p_frame,
  *
  * @param[in]  p_frame  Pointer to the buffer containing PSDU of the transmitted frame.
  * @param[in]  p_ack    Pointer to the buffer containing the received ACK payload (PHR excluding FCS).
-  *                     If ACK was not requested, @p p_ack is set to NULL.
+ *                      If ACK was not requested, @p p_ack is set to NULL.
  * @param[in]  length   Length of the received ACK payload.
  * @param[in]  power    RSSI of received frame or 0 if ACK was not requested.
  * @param[in]  lqi      LQI of received frame or 0 if ACK was not requested.
@@ -752,7 +748,6 @@ extern void nrf_802154_cca_done(bool channel_free);
  * @param[in]  error  Reason of the failure.
  */
 extern void nrf_802154_cca_failed(nrf_802154_cca_error_t error);
-
 
 /**
  * @}
@@ -822,7 +817,6 @@ bool nrf_802154_buffer_free_immediately(uint8_t * p_data);
 
 #endif // NRF_802154_USE_RAW_API
 
-
 /**
  * @}
  * @defgroup nrf_802154_rssi RSSI measurement function
@@ -845,7 +839,6 @@ void nrf_802154_rssi_measure(void);
  * @returns RSSI measurement result [dBm].
  */
 int8_t nrf_802154_rssi_last_get(void);
-
 
 /**
  * @}
@@ -875,7 +868,6 @@ void nrf_802154_promiscuous_set(bool enabled);
  * @retval False  Radio is not in promiscuous mode.
  */
 bool nrf_802154_promiscuous_get(void);
-
 
 /**
  * @}
@@ -958,7 +950,7 @@ void nrf_802154_auto_pending_bit_set(bool enabled);
  * @retval True   If the address is successfully added to the list.
  * @retval False  If there is not enough memory to store the address in the list.
  */
-bool nrf_802154_pending_bit_for_addr_set(const uint8_t *p_addr, bool extended);
+bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
 
 /**
  * @brief Remove address of a peer node for which there is no more pending data in the buffer.
@@ -969,7 +961,7 @@ bool nrf_802154_pending_bit_for_addr_set(const uint8_t *p_addr, bool extended);
  * @retval True   If the address is successfully removed from the list.
  * @retval False  If there is no such address in the list.
  */
-bool nrf_802154_pending_bit_for_addr_clear(const uint8_t *p_addr, bool extended);
+bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended);
 
 /**
  * @brief Remove all addresses of a given type from the pending bit list.
@@ -1063,9 +1055,9 @@ void nrf_802154_transmit_csma_ca(const uint8_t * p_data, uint8_t length);
 
 /**
  * @brief Set timeout for the ACK timeout feature.
- * 
+ *
  * A timeout is notified by @ref nrf_802154_transmit_failed.
- * 
+ *
  * @param[in]  time  Timeout in us.
  *                   A default value is defined in nrf_802154_config.h.
  */

--- a/src/nrf_802154_ack_pending_bit.c
+++ b/src/nrf_802154_ack_pending_bit.c
@@ -50,9 +50,9 @@
 /// Maximum number of Extended Addresses of nodes for which there is pending data in buffer.
 #define NUM_PENDING_EXTENDED_ADDRESSES  NRF_802154_PENDING_EXTENDED_ADDRESSES
 /// Value used to mark Short Address as unused.
-#define UNUSED_PENDING_SHORT_ADDRESS    ((uint8_t [SHORT_ADDRESS_SIZE]) {0xff, 0xff})
+#define UNUSED_PENDING_SHORT_ADDRESS    ((uint8_t[SHORT_ADDRESS_SIZE]) {0xff, 0xff})
 /// Value used to mark Extended Address as unused.
-#define UNUSED_PENDING_EXTENDED_ADDRESS ((uint8_t [EXTENDED_ADDRESS_SIZE]) {0})
+#define UNUSED_PENDING_EXTENDED_ADDRESS ((uint8_t[EXTENDED_ADDRESS_SIZE]) {0})
 
 /// If pending bit in ACK frame should be set to valid or default value.
 static bool m_setting_pending_bit_enabled;
@@ -139,7 +139,9 @@ static int8_t short_addr_compare(const uint8_t * p_first_addr, const uint8_t * p
  * @retval  0  First address is equal to the second address.
  * @retval  1  First address is greater than the second address.
  */
-static int8_t addr_compare(const uint8_t * p_first_addr, const uint8_t * p_second_addr, bool extended)
+static int8_t addr_compare(const uint8_t * p_first_addr,
+                           const uint8_t * p_second_addr,
+                           bool            extended)
 {
     if (extended)
     {
@@ -258,12 +260,12 @@ static bool addr_index_find(const uint8_t * p_addr,
  */
 static bool addr_add(const uint8_t * p_addr, uint8_t location, bool extended)
 {
-    uint8_t * p_addr_array       = extended ? (uint8_t *)m_pending_extended :
-                                              (uint8_t *)m_pending_short;
-    uint8_t   max_addr_array_len = extended ? NUM_PENDING_EXTENDED_ADDRESSES :
-                                              NUM_PENDING_SHORT_ADDRESSES;
-    uint8_t * p_addr_array_len   = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
-    uint8_t   entry_size         = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
+    uint8_t * p_addr_array = extended ? (uint8_t *)m_pending_extended :
+                             (uint8_t *)m_pending_short;
+    uint8_t max_addr_array_len = extended ? NUM_PENDING_EXTENDED_ADDRESSES :
+                                 NUM_PENDING_SHORT_ADDRESSES;
+    uint8_t * p_addr_array_len = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
+    uint8_t   entry_size       = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
 
     if (*p_addr_array_len == max_addr_array_len)
     {
@@ -292,10 +294,10 @@ static bool addr_add(const uint8_t * p_addr, uint8_t location, bool extended)
  */
 static bool addr_remove(uint8_t location, bool extended)
 {
-    uint8_t * p_addr_array       = extended ? (uint8_t *)m_pending_extended :
-                                              (uint8_t *)m_pending_short;
-    uint8_t * p_addr_array_len   = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
-    uint8_t   entry_size         = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
+    uint8_t * p_addr_array = extended ? (uint8_t *)m_pending_extended :
+                             (uint8_t *)m_pending_short;
+    uint8_t * p_addr_array_len = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
+    uint8_t   entry_size       = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
 
     if (*p_addr_array_len == 0)
     {

--- a/src/nrf_802154_ack_pending_bit.c
+++ b/src/nrf_802154_ack_pending_bit.c
@@ -260,12 +260,15 @@ static bool addr_index_find(const uint8_t * p_addr,
  */
 static bool addr_add(const uint8_t * p_addr, uint8_t location, bool extended)
 {
-    uint8_t * p_addr_array = extended ? (uint8_t *)m_pending_extended :
-                             (uint8_t *)m_pending_short;
-    uint8_t max_addr_array_len = extended ? NUM_PENDING_EXTENDED_ADDRESSES :
-                                 NUM_PENDING_SHORT_ADDRESSES;
-    uint8_t * p_addr_array_len = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
-    uint8_t   entry_size       = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
+    uint8_t * p_addr_array;
+    uint8_t   max_addr_array_len;
+    uint8_t * p_addr_array_len;
+    uint8_t   entry_size;
+
+    p_addr_array       = extended ? (uint8_t *)m_pending_extended : (uint8_t *)m_pending_short;
+    max_addr_array_len = extended ? NUM_PENDING_EXTENDED_ADDRESSES : NUM_PENDING_SHORT_ADDRESSES;
+    p_addr_array_len   = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
+    entry_size         = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
 
     if (*p_addr_array_len == max_addr_array_len)
     {
@@ -294,10 +297,13 @@ static bool addr_add(const uint8_t * p_addr, uint8_t location, bool extended)
  */
 static bool addr_remove(uint8_t location, bool extended)
 {
-    uint8_t * p_addr_array = extended ? (uint8_t *)m_pending_extended :
-                             (uint8_t *)m_pending_short;
-    uint8_t * p_addr_array_len = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
-    uint8_t   entry_size       = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
+    uint8_t * p_addr_array;
+    uint8_t * p_addr_array_len;
+    uint8_t   entry_size;
+
+    p_addr_array     = extended ? (uint8_t *)m_pending_extended : (uint8_t *)m_pending_short;
+    p_addr_array_len = extended ? &m_num_of_pending_extended : &m_num_of_pending_short;
+    entry_size       = extended ? EXTENDED_ADDRESS_SIZE : SHORT_ADDRESS_SIZE;
 
     if (*p_addr_array_len == 0)
     {

--- a/src/nrf_802154_ack_pending_bit.h
+++ b/src/nrf_802154_ack_pending_bit.h
@@ -108,4 +108,3 @@ bool nrf_802154_ack_pending_bit_should_be_set(const uint8_t * p_psdu);
 #endif
 
 #endif /* NRF_802154_ACK_PENDING_BIT_H_ */
-

--- a/src/nrf_802154_config.h
+++ b/src/nrf_802154_config.h
@@ -60,7 +60,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_CCA_MODE_DEFAULT
-#define NRF_802154_CCA_MODE_DEFAULT  NRF_RADIO_CCA_MODE_ED
+#define NRF_802154_CCA_MODE_DEFAULT NRF_RADIO_CCA_MODE_ED
 #endif
 
 /**
@@ -70,7 +70,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_CCA_ED_THRESHOLD_DEFAULT
-#define NRF_802154_CCA_ED_THRESHOLD_DEFAULT  0x14
+#define NRF_802154_CCA_ED_THRESHOLD_DEFAULT 0x14
 #endif
 
 /**
@@ -80,7 +80,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_CCA_CORR_THRESHOLD_DEFAULT
-#define NRF_802154_CCA_CORR_THRESHOLD_DEFAULT  0x14
+#define NRF_802154_CCA_CORR_THRESHOLD_DEFAULT 0x14
 #endif
 
 /**
@@ -90,7 +90,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_CCA_CORR_LIMIT_DEFAULT
-#define NRF_802154_CCA_CORR_LIMIT_DEFAULT  0x02
+#define NRF_802154_CCA_CORR_LIMIT_DEFAULT 0x02
 #endif
 
 /**
@@ -107,7 +107,7 @@ extern "C" {
 #define NRF_802154_INTERNAL_RADIO_IRQ_HANDLING 0
 #else // RAAL_SOFTDEVICE
 #define NRF_802154_INTERNAL_RADIO_IRQ_HANDLING 1
-#endif // RAAL_SOFTDEVICE
+#endif  // RAAL_SOFTDEVICE
 
 #endif // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 
@@ -120,7 +120,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_IRQ_PRIORITY
-#define NRF_802154_IRQ_PRIORITY  0
+#define NRF_802154_IRQ_PRIORITY 0
 #endif
 
 /**
@@ -213,7 +213,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_PENDING_SHORT_ADDRESSES
-#define NRF_802154_PENDING_SHORT_ADDRESSES  10
+#define NRF_802154_PENDING_SHORT_ADDRESSES 10
 #endif
 
 /**
@@ -223,7 +223,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_PENDING_EXTENDED_ADDRESSES
-#define NRF_802154_PENDING_EXTENDED_ADDRESSES  10
+#define NRF_802154_PENDING_EXTENDED_ADDRESSES 10
 #endif
 
 /**
@@ -233,7 +233,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_RX_BUFFERS
-#define NRF_802154_RX_BUFFERS  16
+#define NRF_802154_RX_BUFFERS 16
 #endif
 
 /**
@@ -256,7 +256,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_NOTIFY_CRCERROR
-#define NRF_802154_NOTIFY_CRCERROR  1
+#define NRF_802154_NOTIFY_CRCERROR 1
 #endif
 
 /**
@@ -330,7 +330,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_RTC_IRQ_PRIORITY
-#define NRF_802154_RTC_IRQ_PRIORITY  6
+#define NRF_802154_RTC_IRQ_PRIORITY 6
 #endif
 
 /**
@@ -343,7 +343,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_RTC_INSTANCE
-#define NRF_802154_RTC_INSTANCE  NRF_RTC2
+#define NRF_802154_RTC_INSTANCE NRF_RTC2
 #endif
 
 /**
@@ -356,9 +356,8 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_RTC_IRQ_HANDLER
-#define NRF_802154_RTC_IRQ_HANDLER  RTC2_IRQHandler
+#define NRF_802154_RTC_IRQ_HANDLER RTC2_IRQHandler
 #endif
-
 
 /**
  * @def NRF_802154_RTC_IRQN
@@ -370,9 +369,8 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_RTC_IRQN
-#define NRF_802154_RTC_IRQN  RTC2_IRQn
+#define NRF_802154_RTC_IRQN RTC2_IRQn
 #endif
-
 
 /**
  * @}

--- a/src/nrf_802154_const.h
+++ b/src/nrf_802154_const.h
@@ -39,77 +39,77 @@
 #include <stdint.h>
 #include "nrf_802154_config.h"
 
-#define ACK_HEADER_WITH_PENDING      0x12      ///< First byte of ACK frame containing pending bit.
-#define ACK_HEADER_WITHOUT_PENDING   0x02      ///< First byte of ACK frame without pending bit.
+#define ACK_HEADER_WITH_PENDING      0x12                                         ///< First byte of ACK frame containing pending bit.
+#define ACK_HEADER_WITHOUT_PENDING   0x02                                         ///< First byte of ACK frame without pending bit.
 
-#define ACK_REQUEST_OFFSET           1         ///< Byte containing Ack request bit (+1 for frame length byte).
-#define ACK_REQUEST_BIT              (1 << 5)  ///< Ack request bit.
+#define ACK_REQUEST_OFFSET           1                                            ///< Byte containing Ack request bit (+1 for frame length byte).
+#define ACK_REQUEST_BIT              (1 << 5)                                     ///< Ack request bit.
 
-#define DEST_ADDR_TYPE_OFFSET        2         ///< Byte containing destination address type (+1 for frame length byte).
-#define DEST_ADDR_TYPE_MASK          0x0c      ///< Mask of bits containing destination address type.
-#define DEST_ADDR_TYPE_EXTENDED      0x0c      ///< Bits containing extended destination address type.
-#define DEST_ADDR_TYPE_NONE          0x00      ///< Bits containing not present destination address type.
-#define DEST_ADDR_TYPE_SHORT         0x08      ///< Bits containing short destination address type.
-#define DEST_ADDR_OFFSET             6         ///< Offset of destination address in Data frame (+1 for frame length byte).
+#define DEST_ADDR_TYPE_OFFSET        2                                            ///< Byte containing destination address type (+1 for frame length byte).
+#define DEST_ADDR_TYPE_MASK          0x0c                                         ///< Mask of bits containing destination address type.
+#define DEST_ADDR_TYPE_EXTENDED      0x0c                                         ///< Bits containing extended destination address type.
+#define DEST_ADDR_TYPE_NONE          0x00                                         ///< Bits containing not present destination address type.
+#define DEST_ADDR_TYPE_SHORT         0x08                                         ///< Bits containing short destination address type.
+#define DEST_ADDR_OFFSET             6                                            ///< Offset of destination address in Data frame (+1 for frame length byte).
 
-#define DSN_OFFSET                   3         ///< Byte containing DSN value (+1 for frame length byte).
+#define DSN_OFFSET                   3                                            ///< Byte containing DSN value (+1 for frame length byte).
 
-#define FRAME_PENDING_OFFSET         1         ///< Byte containing pending bit (+1 for frame length byte).
-#define FRAME_PENDING_BIT            (1 << 4)  ///< Pending bit.
+#define FRAME_PENDING_OFFSET         1                                            ///< Byte containing pending bit (+1 for frame length byte).
+#define FRAME_PENDING_BIT            (1 << 4)                                     ///< Pending bit.
 
-#define FRAME_TYPE_OFFSET            1         ///< Byte containing frame type bits (+1 for frame length byte).
-#define FRAME_TYPE_MASK              0x07      ///< Mask of bits containing frame type.
-#define FRAME_TYPE_ACK               0x02      ///< Bits containing ACK frame type.
-#define FRAME_TYPE_BEACON            0x00      ///< Bits containing Beacon frame type.
-#define FRAME_TYPE_COMMAND           0x03      ///< Bits containing Command frame type.
-#define FRAME_TYPE_DATA              0x01      ///< Bits containing Data frame type.
-#define FRAME_TYPE_EXTENDED          0x07      ///< Bits containing Extended frame type.
-#define FRAME_TYPE_FRAGMENT          0x06      ///< Bits containing Fragment or Frak frame type.
-#define FRAME_TYPE_MULTIPURPOSE      0x05      ///< Bits containing Multipurpose frame type.
+#define FRAME_TYPE_OFFSET            1                                            ///< Byte containing frame type bits (+1 for frame length byte).
+#define FRAME_TYPE_MASK              0x07                                         ///< Mask of bits containing frame type.
+#define FRAME_TYPE_ACK               0x02                                         ///< Bits containing ACK frame type.
+#define FRAME_TYPE_BEACON            0x00                                         ///< Bits containing Beacon frame type.
+#define FRAME_TYPE_COMMAND           0x03                                         ///< Bits containing Command frame type.
+#define FRAME_TYPE_DATA              0x01                                         ///< Bits containing Data frame type.
+#define FRAME_TYPE_EXTENDED          0x07                                         ///< Bits containing Extended frame type.
+#define FRAME_TYPE_FRAGMENT          0x06                                         ///< Bits containing Fragment or Frak frame type.
+#define FRAME_TYPE_MULTIPURPOSE      0x05                                         ///< Bits containing Multipurpose frame type.
 
-#define FRAME_VERSION_OFFSET         2         ///< Byte containing frame version bits (+1 for frame length byte).
-#define FRAME_VERSION_MASK           0x30      ///< Mask of bits containing frame version.
-#define FRAME_VERSION_0              0x00      ///< Bits containing frame version 0b00.
-#define FRAME_VERSION_1              0x10      ///< Bits containing frame version 0b01.
-#define FRAME_VERSION_2              0x20      ///< Bits containing frame version 0b10.
-#define FRAME_VERSION_3              0x30      ///< Bits containing frame version 0b11.
+#define FRAME_VERSION_OFFSET         2                                            ///< Byte containing frame version bits (+1 for frame length byte).
+#define FRAME_VERSION_MASK           0x30                                         ///< Mask of bits containing frame version.
+#define FRAME_VERSION_0              0x00                                         ///< Bits containing frame version 0b00.
+#define FRAME_VERSION_1              0x10                                         ///< Bits containing frame version 0b01.
+#define FRAME_VERSION_2              0x20                                         ///< Bits containing frame version 0b10.
+#define FRAME_VERSION_3              0x30                                         ///< Bits containing frame version 0b11.
 
-#define PAN_ID_COMPR_OFFSET          1         ///< Byte containing Pan Id compression bit (+1 for frame length byte).
-#define PAN_ID_COMPR_MASK            0x40      ///< Pan Id compression bit.
+#define PAN_ID_COMPR_OFFSET          1                                            ///< Byte containing Pan Id compression bit (+1 for frame length byte).
+#define PAN_ID_COMPR_MASK            0x40                                         ///< Pan Id compression bit.
 
-#define PAN_ID_OFFSET                4         ///< Offset of Pan Id in Data frame (+1 for frame length byte).
+#define PAN_ID_OFFSET                4                                            ///< Offset of Pan Id in Data frame (+1 for frame length byte).
 
-#define SRC_ADDR_TYPE_EXTENDED       0xc0      ///< Bits containing extended source address type.
-#define SRC_ADDR_TYPE_NONE           0x00      ///< Bits containing not present source address type.
-#define SRC_ADDR_TYPE_MASK           0xc0      ///< Mask of bits containing source address type.
-#define SRC_ADDR_TYPE_OFFSET         2         ///< Byte containing source address type (+1 for frame length byte).
-#define SRC_ADDR_TYPE_SHORT          0x80      ///< Bits containing short source address type.
+#define SRC_ADDR_TYPE_EXTENDED       0xc0                                         ///< Bits containing extended source address type.
+#define SRC_ADDR_TYPE_NONE           0x00                                         ///< Bits containing not present source address type.
+#define SRC_ADDR_TYPE_MASK           0xc0                                         ///< Mask of bits containing source address type.
+#define SRC_ADDR_TYPE_OFFSET         2                                            ///< Byte containing source address type (+1 for frame length byte).
+#define SRC_ADDR_TYPE_SHORT          0x80                                         ///< Bits containing short source address type.
 
-#define SRC_ADDR_OFFSET_SHORT_DST    8         ///< Offset of source address in Data frame if destination address is short.
-#define SRC_ADDR_OFFSET_EXTENDED_DST 14        ///< Offset of source address in Data frame if destination address is extended.
+#define SRC_ADDR_OFFSET_SHORT_DST    8                                            ///< Offset of source address in Data frame if destination address is short.
+#define SRC_ADDR_OFFSET_EXTENDED_DST 14                                           ///< Offset of source address in Data frame if destination address is extended.
 
-#define PHR_SIZE              1    ///< Size of PHR field.
-#define FCF_SIZE              2    ///< Size of FCF field.
-#define PAN_ID_SIZE           2    ///< Size of Pan Id.
-#define SHORT_ADDRESS_SIZE    2    ///< Size of Short Mac Address.
-#define EXTENDED_ADDRESS_SIZE 8    ///< Size of Extended Mac Address.
-#define FCS_SIZE              2    ///< Size of FCS field.
-#define IMM_ACK_LENGTH        5    ///< Length of ACK frame.
-#define MAX_PACKET_SIZE       127  ///< Maximum size of radio packet.
+#define PHR_SIZE                     1                                            ///< Size of PHR field.
+#define FCF_SIZE                     2                                            ///< Size of FCF field.
+#define PAN_ID_SIZE                  2                                            ///< Size of Pan Id.
+#define SHORT_ADDRESS_SIZE           2                                            ///< Size of Short Mac Address.
+#define EXTENDED_ADDRESS_SIZE        8                                            ///< Size of Extended Mac Address.
+#define FCS_SIZE                     2                                            ///< Size of FCS field.
+#define IMM_ACK_LENGTH               5                                            ///< Length of ACK frame.
+#define MAX_PACKET_SIZE              127                                          ///< Maximum size of radio packet.
 
-#define TURNAROUND_TIME       192UL                         ///< aTurnaroundTime [us].
-#define CCA_TIME              128UL                         ///< aCcaTime [us].
-#define UNIT_BACKOFF_PERIOD   (TURNAROUND_TIME + CCA_TIME)  ///< aUnitBackoffPeriod [us].
+#define TURNAROUND_TIME              192UL                                        ///< aTurnaroundTime [us].
+#define CCA_TIME                     128UL                                        ///< aCcaTime [us].
+#define UNIT_BACKOFF_PERIOD          (TURNAROUND_TIME + CCA_TIME)                 ///< aUnitBackoffPeriod [us].
 
-#define PHY_US_PER_SYMBOL      16 ///< Duration of a single symbol in microseconds [us].
-#define PHY_SYMBOLS_PER_OCTET  2  ///< Number of symbols in a single byte (octet).
-#define PHY_SHR_SYMBOLS        10 ///< Number of symbols in Synchronization Header (SHR).
+#define PHY_US_PER_SYMBOL            16                                           ///< Duration of a single symbol in microseconds [us].
+#define PHY_SYMBOLS_PER_OCTET        2                                            ///< Number of symbols in a single byte (octet).
+#define PHY_SHR_SYMBOLS              10                                           ///< Number of symbols in Synchronization Header (SHR).
 
-#define ED_MIN_DBM       (-94) ///< dBm value corresponding to value 0 in EDSAMPLE register.
-#define ED_RESULT_FACTOR 4     ///< Factor needed to calculate ED result based on data from RADIO peripheral.
-#define ED_RESULT_MAX    0xff  ///< Maximal ED result.
+#define ED_MIN_DBM                   (-94)                                        ///< dBm value corresponding to value 0 in EDSAMPLE register.
+#define ED_RESULT_FACTOR             4                                            ///< Factor needed to calculate ED result based on data from RADIO peripheral.
+#define ED_RESULT_MAX                0xff                                         ///< Maximal ED result.
 
-#define BROADCAST_ADDRESS    ((uint8_t [SHORT_ADDRESS_SIZE]) {0xff, 0xff}) ///< Broadcast Short Address.
+#define BROADCAST_ADDRESS            ((uint8_t[SHORT_ADDRESS_SIZE]) {0xff, 0xff}) ///< Broadcast Short Address.
 
 typedef enum
 {

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -66,31 +66,30 @@
 
 #include "nrf_802154_core_hooks.h"
 
+#define EGU_EVENT                  NRF_EGU_EVENT_TRIGGERED15
+#define EGU_TASK                   NRF_EGU_TASK_TRIGGER15
+#define PPI_CH0                    NRF_PPI_CHANNEL6
+#define PPI_CH1                    NRF_PPI_CHANNEL7
+#define PPI_CH2                    NRF_PPI_CHANNEL8
+#define PPI_CH3                    NRF_PPI_CHANNEL9
+#define PPI_CH4                    NRF_PPI_CHANNEL10
+#define PPI_CH5                    NRF_PPI_CHANNEL11
+#define PPI_CH6                    NRF_PPI_CHANNEL12
+#define PPI_CHGRP0                 NRF_PPI_CHANNEL_GROUP0 ///< PPI group used to disable self-disabling PPIs
+#define PPI_CHGRP0_DIS_TASK        NRF_PPI_TASK_CHG0_DIS
 
-#define EGU_EVENT           NRF_EGU_EVENT_TRIGGERED15
-#define EGU_TASK            NRF_EGU_TASK_TRIGGER15
-#define PPI_CH0             NRF_PPI_CHANNEL6
-#define PPI_CH1             NRF_PPI_CHANNEL7
-#define PPI_CH2             NRF_PPI_CHANNEL8
-#define PPI_CH3             NRF_PPI_CHANNEL9
-#define PPI_CH4             NRF_PPI_CHANNEL10
-#define PPI_CH5             NRF_PPI_CHANNEL11
-#define PPI_CH6             NRF_PPI_CHANNEL12
-#define PPI_CHGRP0          NRF_PPI_CHANNEL_GROUP0  ///< PPI group used to disable self-disabling PPIs
-#define PPI_CHGRP0_DIS_TASK NRF_PPI_TASK_CHG0_DIS
-
-#define PPI_DISABLED_EGU            PPI_CH0  ///< PPI that connects RADIO DISABLED event with EGU task
-#define PPI_EGU_RAMP_UP             PPI_CH1  ///< PPI that connects EGU event with RADIO TXEN or RXEN task
-#define PPI_EGU_TIMER_START         PPI_CH2  ///< PPI that connects EGU event with TIMER START task
-#define PPI_CRCERROR_CLEAR          PPI_CH3  ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
-#define PPI_CCAIDLE_FEM             PPI_CH3  ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
-#define PPI_TIMER_TX_ACK            PPI_CH3  ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
-#define PPI_CRCOK_DIS_PPI           PPI_CH4  ///< PPI that connects RADIO CRCOK event with task that disables PPI group
+#define PPI_DISABLED_EGU           PPI_CH0 ///< PPI that connects RADIO DISABLED event with EGU task
+#define PPI_EGU_RAMP_UP            PPI_CH1 ///< PPI that connects EGU event with RADIO TXEN or RXEN task
+#define PPI_EGU_TIMER_START        PPI_CH2 ///< PPI that connects EGU event with TIMER START task
+#define PPI_CRCERROR_CLEAR         PPI_CH3 ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#define PPI_CCAIDLE_FEM            PPI_CH3 ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
+#define PPI_TIMER_TX_ACK           PPI_CH3 ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
+#define PPI_CRCOK_DIS_PPI          PPI_CH4 ///< PPI that connects RADIO CRCOK event with task that disables PPI group
 
 #if NRF_802154_DISABLE_BCC_MATCHING
-#define PPI_ADDRESS_COUNTER_COUNT   PPI_CH5  ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
-#define PPI_CRCERROR_COUNTER_CLEAR  PPI_CH6  ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#define PPI_ADDRESS_COUNTER_COUNT  PPI_CH5 ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
+#define PPI_CRCERROR_COUNTER_CLEAR PPI_CH6 ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
 
 /// Workaround for missing PHYEND event in older chip revision.
 static inline uint32_t short_phyend_disable_mask_get(void)
@@ -104,70 +103,69 @@ static inline uint32_t short_phyend_disable_mask_get(void)
 }
 
 #if NRF_802154_DISABLE_BCC_MATCHING
-#define SHORT_ADDRESS_BCSTART    0UL
+#define SHORT_ADDRESS_BCSTART 0UL
 #else // NRF_802154_DISABLE_BCC_MATCHING
-#define SHORT_ADDRESS_BCSTART    NRF_RADIO_SHORT_ADDRESS_BCSTART_MASK
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#define SHORT_ADDRESS_BCSTART NRF_RADIO_SHORT_ADDRESS_BCSTART_MASK
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
 
 /// Value set to SHORTS register when no shorts should be enabled.
-#define SHORTS_IDLE           0
+#define SHORTS_IDLE             0
 
 /// Value set to SHORTS register for RX operation.
-#define SHORTS_RX             (NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK  |                           \
-                               NRF_RADIO_SHORT_END_DISABLE_MASK |                                  \
-                               SHORT_ADDRESS_BCSTART)
+#define SHORTS_RX               (NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK | \
+                                 NRF_RADIO_SHORT_END_DISABLE_MASK |       \
+                                 SHORT_ADDRESS_BCSTART)
 
-#define SHORTS_RX_FREE_BUFFER (NRF_RADIO_SHORT_RXREADY_START_MASK)
+#define SHORTS_RX_FREE_BUFFER   (NRF_RADIO_SHORT_RXREADY_START_MASK)
 
-#define SHORTS_TX_ACK         (NRF_RADIO_SHORT_TXREADY_START_MASK |                                \
-                               short_phyend_disable_mask_get())
+#define SHORTS_TX_ACK           (NRF_RADIO_SHORT_TXREADY_START_MASK | \
+                                 short_phyend_disable_mask_get())
 
-#define SHORTS_CCA_TX         (NRF_RADIO_SHORT_RXREADY_CCASTART_MASK |                             \
-                               NRF_RADIO_SHORT_CCABUSY_DISABLE_MASK  |                             \
-                               NRF_RADIO_SHORT_CCAIDLE_TXEN_MASK     |                             \
-                               NRF_RADIO_SHORT_TXREADY_START_MASK    |                             \
-                               short_phyend_disable_mask_get())
+#define SHORTS_CCA_TX           (NRF_RADIO_SHORT_RXREADY_CCASTART_MASK | \
+                                 NRF_RADIO_SHORT_CCABUSY_DISABLE_MASK |  \
+                                 NRF_RADIO_SHORT_CCAIDLE_TXEN_MASK |     \
+                                 NRF_RADIO_SHORT_TXREADY_START_MASK |    \
+                                 short_phyend_disable_mask_get())
 
-#define SHORTS_TX             (NRF_RADIO_SHORT_TXREADY_START_MASK |                                \
-                               short_phyend_disable_mask_get())
+#define SHORTS_TX               (NRF_RADIO_SHORT_TXREADY_START_MASK | \
+                                 short_phyend_disable_mask_get())
 
-#define SHORTS_RX_ACK         (NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK |                            \
-                               NRF_RADIO_SHORT_END_DISABLE_MASK)
+#define SHORTS_RX_ACK           (NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK | \
+                                 NRF_RADIO_SHORT_END_DISABLE_MASK)
 
-#define SHORTS_ED             (NRF_RADIO_SHORT_READY_EDSTART_MASK)
+#define SHORTS_ED               (NRF_RADIO_SHORT_READY_EDSTART_MASK)
 
-#define SHORTS_CCA            (NRF_RADIO_SHORT_RXREADY_CCASTART_MASK |                             \
-                               NRF_RADIO_SHORT_CCABUSY_DISABLE_MASK)
+#define SHORTS_CCA              (NRF_RADIO_SHORT_RXREADY_CCASTART_MASK | \
+                                 NRF_RADIO_SHORT_CCABUSY_DISABLE_MASK)
 
 /// Delay before first check of received frame: 24 bits is PHY header and MAC Frame Control field.
-#define BCC_INIT            (3 * 8)
+#define BCC_INIT                (3 * 8)
 
 /// Duration of single iteration of Energy Detection procedure
-#define ED_ITER_DURATION   128U
+#define ED_ITER_DURATION        128U
 /// Overhead of hardware preparation for ED procedure (aTurnaroundTime) [number of iterations]
-#define ED_ITERS_OVERHEAD  2U
+#define ED_ITERS_OVERHEAD       2U
 
-#define CRC_LENGTH      2         ///< Length of CRC in 802.15.4 frames [bytes]
-#define CRC_POLYNOMIAL  0x011021  ///< Polynomial used for CRC calculation in 802.15.4 frames
+#define CRC_LENGTH              2               ///< Length of CRC in 802.15.4 frames [bytes]
+#define CRC_POLYNOMIAL          0x011021        ///< Polynomial used for CRC calculation in 802.15.4 frames
 
-#define MHMU_MASK               0xff000700  ///< Mask of known bytes in ACK packet
-#define MHMU_PATTERN            0x00000200  ///< Values of known bytes in ACK packet
-#define MHMU_PATTERN_DSN_OFFSET 24          ///< Offset of DSN in MHMU_PATTER [bits]
+#define MHMU_MASK               0xff000700      ///< Mask of known bytes in ACK packet
+#define MHMU_PATTERN            0x00000200      ///< Values of known bytes in ACK packet
+#define MHMU_PATTERN_DSN_OFFSET 24              ///< Offset of DSN in MHMU_PATTER [bits]
 
-#define ACK_IFS    TURNAROUND_TIME  ///< Ack Inter Frame Spacing [us] - delay between last symbol of received frame and first symbol of transmitted Ack
-#define TXRU_TIME  40               ///< Transmitter ramp up time [us]
-#define EVENT_LAT  23               ///< END event latency [us]
+#define ACK_IFS                 TURNAROUND_TIME ///< Ack Inter Frame Spacing [us] - delay between last symbol of received frame and first symbol of transmitted Ack
+#define TXRU_TIME               40              ///< Transmitter ramp up time [us]
+#define EVENT_LAT               23              ///< END event latency [us]
 
-#define MAX_CRIT_SECT_TIME 60  ///< Maximal time that the driver spends in single critical section.
+#define MAX_CRIT_SECT_TIME      60              ///< Maximal time that the driver spends in single critical section.
 
-#define LQI_VALUE_FACTOR 4     ///< Factor needed to calculate LQI value based on data from RADIO peripheral
-#define LQI_MAX          0xff  ///< Maximal LQI value
-
+#define LQI_VALUE_FACTOR        4               ///< Factor needed to calculate LQI value based on data from RADIO peripheral
+#define LQI_MAX                 0xff            ///< Maximal LQI value
 
 /** Get LQI of given received packet. If CRC is calculated by hardware LQI is included instead of CRC
  *  in the frame. Length is stored in byte with index 0; CRC is 2 last bytes.
  */
-#define RX_FRAME_LQI(psdu)  ((psdu)[(psdu)[0] - 1])
+#define RX_FRAME_LQI(psdu)      ((psdu)[(psdu)[0] - 1])
 
 #if NRF_802154_RX_BUFFERS > 1
 /// Pointer to currently used receive buffer.
@@ -182,22 +180,22 @@ static const uint8_t * mp_tx_data;                     ///< Pointer to the data 
 static uint32_t        m_ed_time_left;                 ///< Remaining time of the current energy detection procedure [us].
 static uint8_t         m_ed_result;                    ///< Result of the current energy detection procedure.
 
-static volatile radio_state_t m_state; ///< State of the radio driver.
+static volatile radio_state_t m_state;                 ///< State of the radio driver.
 
 typedef struct
 {
-    bool frame_filtered        :1;  ///< If frame being received passed filtering operation.
-    bool rx_timeslot_requested :1;  ///< If timeslot for the frame being received is already requested.
+    bool frame_filtered        : 1; ///< If frame being received passed filtering operation.
+    bool rx_timeslot_requested : 1; ///< If timeslot for the frame being received is already requested.
 #if !NRF_802154_DISABLE_BCC_MATCHING
-    bool psdu_being_received   :1;  ///< If PSDU is currently being received.
-#endif // !NRF_802154_DISABLE_BCC_MATCHING
+    bool psdu_being_received : 1;   ///< If PSDU is currently being received.
+#endif  // !NRF_802154_DISABLE_BCC_MATCHING
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
-    bool tx_started            :1;  ///< If requested transmission has started.
-#endif // NRF_802154_TX_STARTED_NOTIFY_ENABLED
+    bool tx_started : 1; ///< If requested transmission has started.
+#endif  // NRF_802154_TX_STARTED_NOTIFY_ENABLED
 } nrf_802154_flags_t;
-static nrf_802154_flags_t m_flags;  ///< Flags used to store current driver state.
+static nrf_802154_flags_t m_flags;               ///< Flags used to store current driver state.
 
-static volatile bool m_rsch_timeslot_is_granted;  ///< State of the RSCH timeslot.
+static volatile bool m_rsch_timeslot_is_granted; ///< State of the RSCH timeslot.
 
 /***************************************************************************************************
  * @section Common core operations
@@ -220,7 +218,7 @@ static void rx_flags_clear(void)
     m_flags.frame_filtered        = false;
     m_flags.rx_timeslot_requested = false;
 #if !NRF_802154_DISABLE_BCC_MATCHING
-    m_flags.psdu_being_received   = false;
+    m_flags.psdu_being_received = false;
 #endif // !NRF_802154_DISABLE_BCC_MATCHING
 }
 
@@ -247,7 +245,7 @@ static uint8_t lqi_get(const uint8_t * p_data)
 {
     uint32_t lqi = RX_FRAME_LQI(p_data);
 
-    lqi = nrf_802154_rssi_lqi_corrected_get(lqi);
+    lqi  = nrf_802154_rssi_lqi_corrected_get(lqi);
     lqi *= LQI_VALUE_FACTOR;
 
     if (lqi > LQI_MAX)
@@ -260,9 +258,9 @@ static uint8_t lqi_get(const uint8_t * p_data)
 
 static void received_frame_notify(uint8_t * p_psdu)
 {
-    nrf_802154_notify_received(p_psdu,                       // data
-                               rssi_last_measurement_get(),  // rssi
-                               lqi_get(p_psdu));             // lqi
+    nrf_802154_notify_received(p_psdu,                      // data
+                               rssi_last_measurement_get(), // rssi
+                               lqi_get(p_psdu));            // lqi
 }
 
 /** Allow nesting critical sections and notify MAC layer that a frame was received. */
@@ -359,7 +357,7 @@ static void cca_configuration_update(void)
     nrf_802154_pib_cca_cfg_get(&cca_cfg);
     nrf_radio_cca_mode_set(cca_cfg.mode);
     nrf_radio_cca_ed_threshold_set(
-            nrf_802154_rssi_cca_ed_threshold_corrected_get(cca_cfg.ed_threshold));
+        nrf_802154_rssi_cca_ed_threshold_corrected_get(cca_cfg.ed_threshold));
     nrf_radio_cca_corr_threshold_set(cca_cfg.corr_threshold);
     nrf_radio_cca_corr_counter_set(cca_cfg.corr_limit);
 }
@@ -371,7 +369,8 @@ static void cca_configuration_update(void)
 static bool psdu_is_being_received(void)
 {
 #if NRF_802154_DISABLE_BCC_MATCHING
-    nrf_timer_task_trigger(NRF_802154_COUNTER_TIMER_INSTANCE, nrf_timer_capture_task_get(NRF_TIMER_CC_CHANNEL0));
+    nrf_timer_task_trigger(NRF_802154_COUNTER_TIMER_INSTANCE,
+                           nrf_timer_capture_task_get(NRF_TIMER_CC_CHANNEL0));
     uint32_t counter = nrf_timer_cc_read(NRF_802154_COUNTER_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0);
 
     assert(counter <= 1);
@@ -379,7 +378,7 @@ static bool psdu_is_being_received(void)
     return counter > 0;
 #else // NRF_802154_DISABLE_BCC_MATCHING
     return m_flags.psdu_being_received;
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
 }
 
 /** Check if requested transmission has already started.
@@ -393,7 +392,7 @@ static bool transmission_has_started(void)
     return m_flags.tx_started;
 #else // NRF_802154_TX_STARTED_NOTIFY_ENABLED
     return nrf_radio_event_get(NRF_RADIO_EVENT_ADDRESS);
-#endif // NRF_802154_TX_STARTED_NOTIFY_ENABLED
+#endif  // NRF_802154_TX_STARTED_NOTIFY_ENABLED
 }
 
 /** Check if timeslot is currently granted.
@@ -419,7 +418,7 @@ static void rx_buffer_in_use_set(rx_buffer_t * p_rx_buffer)
 #if NRF_802154_RX_BUFFERS > 1
     mp_current_rx_buffer = p_rx_buffer;
 #else
-    (void) p_rx_buffer;
+    (void)p_rx_buffer;
 #endif
 }
 
@@ -500,7 +499,7 @@ static void ack_matching_enable(void)
 {
     nrf_radio_event_clear(NRF_RADIO_EVENT_MHRMATCH);
     nrf_radio_mhmu_search_pattern_set(MHMU_PATTERN |
-                                      ((uint32_t) mp_tx_data[DSN_OFFSET] <<
+                                      ((uint32_t)mp_tx_data[DSN_OFFSET] <<
                                        MHMU_PATTERN_DSN_OFFSET));
 }
 
@@ -519,7 +518,7 @@ static void ack_matching_disable(void)
 static bool ack_is_matched(void)
 {
     return (nrf_radio_event_get(NRF_RADIO_EVENT_MHRMATCH)) &&
-            (nrf_radio_crc_status_get() == NRF_RADIO_CRC_STATUS_OK);
+           (nrf_radio_crc_status_get() == NRF_RADIO_CRC_STATUS_OK);
 }
 
 /***************************************************************************************************
@@ -579,7 +578,6 @@ static void irq_deinit(void)
     __ISB();
 }
 
-
 /***************************************************************************************************
  * @section TIMER peripheral management
  **************************************************************************************************/
@@ -610,7 +608,7 @@ static uint8_t ed_result_get(void)
 {
     uint32_t result = m_ed_result;
 
-    result = nrf_802154_rssi_ed_corrected_get(result);
+    result  = nrf_802154_rssi_ed_corrected_get(result);
     result *= ED_RESULT_FACTOR;
 
     if (result > ED_RESULT_MAX)
@@ -665,7 +663,6 @@ static bool ed_iter_setup(uint32_t time_us)
         return false;
     }
 }
-
 
 /***************************************************************************************************
  * @section FSM transition request sub-procedures
@@ -728,26 +725,26 @@ static void ppis_for_egu_and_ramp_up_set(nrf_radio_task_t ramp_up_task, bool sel
     {
         nrf_ppi_channel_and_fork_endpoint_setup(PPI_EGU_RAMP_UP,
                                                 (uint32_t)nrf_egu_event_address_get(
-                                                        NRF_802154_SWI_EGU_INSTANCE,
-                                                        EGU_EVENT),
+                                                    NRF_802154_SWI_EGU_INSTANCE,
+                                                    EGU_EVENT),
                                                 (uint32_t)nrf_radio_task_address_get(ramp_up_task),
                                                 (uint32_t)nrf_ppi_task_address_get(
-                                                        PPI_CHGRP0_DIS_TASK));
+                                                    PPI_CHGRP0_DIS_TASK));
     }
     else
     {
         nrf_ppi_channel_endpoint_setup(PPI_EGU_RAMP_UP,
                                        (uint32_t)nrf_egu_event_address_get(
-                                               NRF_802154_SWI_EGU_INSTANCE,
-                                               EGU_EVENT),
+                                           NRF_802154_SWI_EGU_INSTANCE,
+                                           EGU_EVENT),
                                        (uint32_t)nrf_radio_task_address_get(ramp_up_task));
     }
 
     nrf_ppi_channel_endpoint_setup(PPI_DISABLED_EGU,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_DISABLED),
                                    (uint32_t)nrf_egu_task_address_get(
-                                           NRF_802154_SWI_EGU_INSTANCE,
-                                           EGU_TASK));
+                                       NRF_802154_SWI_EGU_INSTANCE,
+                                       EGU_TASK));
 
     if (self_disabling)
     {
@@ -767,8 +764,8 @@ static void fem_for_lna_set(nrf_timer_cc_channel_t cc_channel,
     nrf_fem_control_ppi_task_setup(NRF_FEM_CONTROL_LNA_PIN,
                                    PPI_EGU_TIMER_START,
                                    (uint32_t)nrf_egu_event_address_get(
-                                        NRF_802154_SWI_EGU_INSTANCE,
-                                        EGU_EVENT),
+                                       NRF_802154_SWI_EGU_INSTANCE,
+                                       EGU_EVENT),
                                    (uint32_t)nrf_timer_task_address_get(
                                        NRF_802154_TIMER_INSTANCE,
                                        NRF_TIMER_TASK_START));
@@ -845,8 +842,8 @@ static void fem_for_tx_reset(bool disable_ppi_egu_timer_start)
 {
     nrf_fem_control_ppi_disable(NRF_FEM_CONTROL_ANY_PIN);
     nrf_fem_control_timer_reset(NRF_FEM_CONTROL_ANY_PIN,
-                                (nrf_timer_short_mask_t) (NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
-                                                          NRF_TIMER_SHORT_COMPARE1_STOP_MASK));
+                                (nrf_timer_short_mask_t)(NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
+                                                         NRF_TIMER_SHORT_COMPARE1_STOP_MASK));
     nrf_fem_control_ppi_fork_clear(NRF_FEM_CONTROL_ANY_PIN, PPI_CCAIDLE_FEM);
     nrf_ppi_channel_disable(PPI_CCAIDLE_FEM);
 
@@ -891,7 +888,7 @@ static void rx_restart(bool set_shorts)
 
     // Prepare the timer coordinator to get a precise timestamp of the CRCOK event.
     nrf_802154_timer_coord_timestamp_prepare(
-            (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
+        (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
 
     if (!ppi_egu_worked())
     {
@@ -973,11 +970,13 @@ static void rx_terminate(void)
     nrf_ppi_fork_endpoint_setup(PPI_EGU_TIMER_START, 0);
 #else // NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_fork_endpoint_setup(PPI_EGU_RAMP_UP, 0);
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
 
     // Anomaly 78: use SHUTDOWN instead of STOP and CLEAR.
     nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-    nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK | NRF_TIMER_SHORT_COMPARE2_STOP_MASK);
+    nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE,
+                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
+                             NRF_TIMER_SHORT_COMPARE2_STOP_MASK);
 
 #if NRF_802154_DISABLE_BCC_MATCHING
     // Anomaly 78: use SHUTDOWN instead of STOP and CLEAR.
@@ -1022,7 +1021,9 @@ static void tx_ack_terminate(void)
 
     // Anomaly 78: use SHUTDOWN instead of STOP and CLEAR.
     nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-    nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK | NRF_TIMER_SHORT_COMPARE2_STOP_MASK);
+    nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE,
+                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
+                             NRF_TIMER_SHORT_COMPARE2_STOP_MASK);
 
 #if NRF_802154_DISABLE_BCC_MATCHING
     // Anomaly 78: use SHUTDOWN instead of STOP and CLEAR.
@@ -1033,7 +1034,7 @@ static void tx_ack_terminate(void)
     if (timeslot_is_granted())
     {
         ints_to_disable = nrf_802154_revision_has_phyend_event() ?
-                NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
+                          NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
         ints_to_disable |= NRF_RADIO_INT_ADDRESS_MASK;
 #endif // NRF_802154_TX_STARTED_NOTIFY_ENABLED
@@ -1060,7 +1061,7 @@ static void tx_terminate(void)
     if (timeslot_is_granted())
     {
         ints_to_disable = nrf_802154_revision_has_phyend_event() ?
-                NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
+                          NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
         ints_to_disable |= NRF_RADIO_INT_CCABUSY_MASK;
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
         ints_to_disable |= NRF_RADIO_INT_ADDRESS_MASK;
@@ -1089,7 +1090,7 @@ static void rx_ack_terminate(void)
         nrf_radio_int_disable(NRF_RADIO_INT_END_MASK);
         nrf_radio_shorts_set(SHORTS_IDLE);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
-        
+
         ack_matching_disable();
     }
 }
@@ -1152,7 +1153,7 @@ static void continuous_carrier_terminate(void)
  *
  * This function is called when MAC layer requests transition to another operation.
  *
- * After calling this function RADIO should enter DISABLED state and Radio Scheduler 
+ * After calling this function RADIO should enter DISABLED state and Radio Scheduler
  * should be in continuous mode.
  *
  * @param[in]  term_lvl      Termination level of this request. Selects procedures to abort.
@@ -1414,64 +1415,64 @@ static void rx_init(bool disabled_was_triggered)
 #if NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_endpoint_setup(PPI_EGU_RAMP_UP,
                                    (uint32_t)nrf_egu_event_address_get(
-                                           NRF_802154_SWI_EGU_INSTANCE,
-                                           EGU_EVENT),
+                                       NRF_802154_SWI_EGU_INSTANCE,
+                                       EGU_EVENT),
                                    (uint32_t)nrf_radio_task_address_get(NRF_RADIO_TASK_RXEN));
     nrf_ppi_channel_and_fork_endpoint_setup(PPI_EGU_TIMER_START,
                                             (uint32_t)nrf_egu_event_address_get(
-                                                    NRF_802154_SWI_EGU_INSTANCE,
-                                                    EGU_EVENT),
+                                                NRF_802154_SWI_EGU_INSTANCE,
+                                                EGU_EVENT),
                                             (uint32_t)nrf_timer_task_address_get(
-                                                    NRF_802154_TIMER_INSTANCE,
-                                                    NRF_TIMER_TASK_START),
+                                                NRF_802154_TIMER_INSTANCE,
+                                                NRF_TIMER_TASK_START),
                                             (uint32_t)nrf_timer_task_address_get(
-                                                    NRF_802154_COUNTER_TIMER_INSTANCE,
-                                                    NRF_TIMER_TASK_START));
+                                                NRF_802154_COUNTER_TIMER_INSTANCE,
+                                                NRF_TIMER_TASK_START));
     // Anomaly 78: use SHUTDOWN instead of CLEAR.
     nrf_ppi_channel_endpoint_setup(PPI_CRCERROR_CLEAR,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCERROR),
                                    (uint32_t)nrf_timer_task_address_get(
-                                           NRF_802154_TIMER_INSTANCE,
-                                           NRF_TIMER_TASK_SHUTDOWN));
+                                       NRF_802154_TIMER_INSTANCE,
+                                       NRF_TIMER_TASK_SHUTDOWN));
     nrf_ppi_channel_endpoint_setup(PPI_CRCOK_DIS_PPI,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK),
                                    (uint32_t)nrf_ppi_task_address_get(PPI_CHGRP0_DIS_TASK));
 #else // NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_and_fork_endpoint_setup(PPI_EGU_RAMP_UP,
                                             (uint32_t)nrf_egu_event_address_get(
-                                                    NRF_802154_SWI_EGU_INSTANCE,
-                                                    EGU_EVENT),
+                                                NRF_802154_SWI_EGU_INSTANCE,
+                                                EGU_EVENT),
                                             (uint32_t)nrf_radio_task_address_get(
-                                                    NRF_RADIO_TASK_RXEN),
+                                                NRF_RADIO_TASK_RXEN),
                                             (uint32_t)nrf_ppi_task_address_get(
-                                                    PPI_CHGRP0_DIS_TASK));
+                                                PPI_CHGRP0_DIS_TASK));
     nrf_ppi_channel_endpoint_setup(PPI_EGU_TIMER_START,
                                    (uint32_t)nrf_egu_event_address_get(
-                                           NRF_802154_SWI_EGU_INSTANCE,
-                                           EGU_EVENT),
+                                       NRF_802154_SWI_EGU_INSTANCE,
+                                       EGU_EVENT),
                                    (uint32_t)nrf_timer_task_address_get(
-                                           NRF_802154_TIMER_INSTANCE,
-                                           NRF_TIMER_TASK_START));
+                                       NRF_802154_TIMER_INSTANCE,
+                                       NRF_TIMER_TASK_START));
 #endif // NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_include_in_group(PPI_EGU_RAMP_UP, PPI_CHGRP0);
 
     nrf_ppi_channel_endpoint_setup(PPI_DISABLED_EGU,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_DISABLED),
                                    (uint32_t)nrf_egu_task_address_get(
-                                           NRF_802154_SWI_EGU_INSTANCE,
-                                           EGU_TASK));
+                                       NRF_802154_SWI_EGU_INSTANCE,
+                                       EGU_TASK));
 #if NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_endpoint_setup(PPI_ADDRESS_COUNTER_COUNT,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_ADDRESS),
                                    (uint32_t)nrf_timer_task_address_get(
-                                           NRF_802154_COUNTER_TIMER_INSTANCE,
-                                           NRF_TIMER_TASK_COUNT));
+                                       NRF_802154_COUNTER_TIMER_INSTANCE,
+                                       NRF_TIMER_TASK_COUNT));
     // Anomaly 78: use SHUTDOWN instead of CLEAR.
     nrf_ppi_channel_endpoint_setup(PPI_CRCERROR_COUNTER_CLEAR,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCERROR),
                                    (uint32_t)nrf_timer_task_address_get(
-                                           NRF_802154_COUNTER_TIMER_INSTANCE,
-                                           NRF_TIMER_TASK_SHUTDOWN));
+                                       NRF_802154_COUNTER_TIMER_INSTANCE,
+                                       NRF_TIMER_TASK_SHUTDOWN));
 #endif // NRF_802154_DISABLE_BCC_MATCHING
 
     nrf_ppi_channel_enable(PPI_EGU_RAMP_UP);
@@ -1486,7 +1487,7 @@ static void rx_init(bool disabled_was_triggered)
 
     // Configure the timer coordinator to get a timestamp of the CRCOK event.
     nrf_802154_timer_coord_timestamp_prepare(
-            (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
+        (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
 
     // Start procedure if necessary
     if (!disabled_was_triggered || !ppi_egu_worked())
@@ -1549,7 +1550,7 @@ static bool tx_init(const uint8_t * p_data, bool cca, bool disabled_was_triggere
 
     nrf_radio_event_clear(NRF_RADIO_EVENT_ADDRESS);
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
-    ints_to_enable |= NRF_RADIO_INT_ADDRESS_MASK;
+    ints_to_enable    |= NRF_RADIO_INT_ADDRESS_MASK;
     m_flags.tx_started = false;
 #endif // NRF_802154_TX_STARTED_NOTIFY_ENABLED
 
@@ -1656,8 +1657,6 @@ static void continuous_carrier_init(bool disabled_was_triggered)
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
     }
 }
-
-
 
 /***************************************************************************************************
  * @section Radio Scheduler notification handlers
@@ -1798,7 +1797,6 @@ void nrf_802154_rsch_crit_sect_prio_changed(rsch_prio_t prio)
     }
 }
 
-
 /***************************************************************************************************
  * @section RADIO interrupt handler
  **************************************************************************************************/
@@ -1842,7 +1840,8 @@ static void irq_bcmatch_state_rx(void)
     if (!m_flags.frame_filtered)
     {
         m_flags.psdu_being_received = true;
-        filter_result = nrf_802154_filter_frame_part(mp_current_rx_buffer->psdu, &num_psdu_bytes);
+        filter_result               = nrf_802154_filter_frame_part(mp_current_rx_buffer->psdu,
+                                                                   &num_psdu_bytes);
 
         if (filter_result == NRF_802154_RX_ERROR_NONE)
         {
@@ -1878,8 +1877,8 @@ static void irq_bcmatch_state_rx(void)
     if ((!m_flags.rx_timeslot_requested) && (frame_accepted))
     {
         if (nrf_802154_rsch_timeslot_request(nrf_802154_rx_duration_get(
-                mp_current_rx_buffer->psdu[0],
-                ack_is_requested(mp_current_rx_buffer->psdu))))
+                                                 mp_current_rx_buffer->psdu[0],
+                                                 ack_is_requested(mp_current_rx_buffer->psdu))))
         {
             m_flags.rx_timeslot_requested = true;
         }
@@ -1892,25 +1891,28 @@ static void irq_bcmatch_state_rx(void)
         }
     }
 }
-#endif //!NRF_802154_DISABLE_BCC_MATCHING
+
+#endif // !NRF_802154_DISABLE_BCC_MATCHING
 
 #if !NRF_802154_DISABLE_BCC_MATCHING || NRF_802154_NOTIFY_CRCERROR
 static void irq_crcerror_state_rx(void)
 {
 #if !NRF_802154_DISABLE_BCC_MATCHING
     rx_restart(false);
-#endif //!NRF_802154_DISABLE_BCC_MATCHING
+#endif // !NRF_802154_DISABLE_BCC_MATCHING
 #if NRF_802154_NOTIFY_CRCERROR
     receive_failed_notify(NRF_802154_RX_ERROR_INVALID_FCS);
-#endif //NRF_802154_NOTIFY_CRCERROR
+#endif // NRF_802154_NOTIFY_CRCERROR
 }
-#endif //!NRF_802154_DISABLE_BCC_MATCHING || NRF_802154_NOTIFY_CRCERROR
+
+#endif // !NRF_802154_DISABLE_BCC_MATCHING || NRF_802154_NOTIFY_CRCERROR
 
 static void irq_crcok_state_rx(void)
 {
     uint8_t * p_received_psdu = mp_current_rx_buffer->psdu;
     uint32_t  ints_to_disable = 0;
     uint32_t  ints_to_enable  = 0;
+
 #if NRF_802154_DISABLE_BCC_MATCHING
     uint8_t               num_psdu_bytes      = PHR_SIZE + FCF_SIZE;
     uint8_t               prev_num_psdu_bytes = 0;
@@ -1988,10 +1990,10 @@ static void irq_crcok_state_rx(void)
             // Set PPIs
             nrf_ppi_channel_endpoint_setup(PPI_TIMER_TX_ACK,
                                            (uint32_t)nrf_timer_event_address_get(
-                                                   NRF_802154_TIMER_INSTANCE,
-                                                   NRF_TIMER_EVENT_COMPARE1),
+                                               NRF_802154_TIMER_INSTANCE,
+                                               NRF_TIMER_EVENT_COMPARE1),
                                            (uint32_t)nrf_radio_task_address_get(
-                                                   NRF_RADIO_TASK_TXEN));
+                                               NRF_RADIO_TASK_TXEN));
 
 #if !NRF_802154_DISABLE_BCC_MATCHING
             nrf_ppi_channel_enable(PPI_TIMER_TX_ACK);
@@ -2125,7 +2127,7 @@ static void irq_crcok_state_rx(void)
         }
 #else // NRF_802154_DISABLE_BCC_MATCHING
         receive_failed_notify(NRF_802154_RX_ERROR_RUNTIME);
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
     }
 }
 
@@ -2150,7 +2152,7 @@ static void irq_phyend_state_tx_ack(void)
 #endif // !NRF_802154_DISABLE_BCC_MATCHING
 
     ints_to_disable = nrf_802154_revision_has_phyend_event() ?
-            NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
+                      NRF_RADIO_INT_PHYEND_MASK : NRF_RADIO_INT_END_MASK;
 
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
     ints_to_disable |= NRF_RADIO_INT_ADDRESS_MASK;
@@ -2186,16 +2188,16 @@ static void irq_phyend_state_tx_ack(void)
     nrf_ppi_channel_endpoint_setup(PPI_CRCERROR_CLEAR,
                                    (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCERROR),
                                    (uint32_t)nrf_timer_task_address_get(
-                                           NRF_802154_TIMER_INSTANCE,
-                                           NRF_TIMER_TASK_SHUTDOWN));
+                                       NRF_802154_TIMER_INSTANCE,
+                                       NRF_TIMER_TASK_SHUTDOWN));
 
     nrf_ppi_fork_endpoint_setup(PPI_EGU_TIMER_START,
                                 (uint32_t)nrf_timer_task_address_get(
-                                        NRF_802154_COUNTER_TIMER_INSTANCE,
-                                        NRF_TIMER_TASK_START));
+                                    NRF_802154_COUNTER_TIMER_INSTANCE,
+                                    NRF_TIMER_TASK_START));
 #else // NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
-#endif // NRF_802154_DISABLE_BCC_MATCHING
+#endif  // NRF_802154_DISABLE_BCC_MATCHING
 
     // Enable PPI disabled by CRCOK
     nrf_ppi_channel_enable(PPI_EGU_RAMP_UP);
@@ -2210,7 +2212,7 @@ static void irq_phyend_state_tx_ack(void)
 
     // Prepare the timer coordinator to get a precise timestamp of the CRCOK event.
     nrf_802154_timer_coord_timestamp_prepare(
-            (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
+        (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
 
     if (!ppi_egu_worked())
     {
@@ -2254,7 +2256,7 @@ static void irq_phyend_state_tx_frame(void)
     {
         bool     rx_buffer_free = rx_buffer_is_available();
         uint32_t shorts         = rx_buffer_free ?
-                (SHORTS_RX_ACK | SHORTS_RX_FREE_BUFFER) : SHORTS_RX_ACK;
+                                  (SHORTS_RX_ACK | SHORTS_RX_FREE_BUFFER) : SHORTS_RX_ACK;
 
         // Disable EGU PPI to prevent unsynchronized PPIs
         nrf_ppi_channel_disable(PPI_DISABLED_EGU);
@@ -2286,12 +2288,12 @@ static void irq_phyend_state_tx_frame(void)
 
         nrf_ppi_channel_and_fork_endpoint_setup(PPI_EGU_RAMP_UP,
                                                 (uint32_t)nrf_egu_event_address_get(
-                                                        NRF_802154_SWI_EGU_INSTANCE,
-                                                        EGU_EVENT),
+                                                    NRF_802154_SWI_EGU_INSTANCE,
+                                                    EGU_EVENT),
                                                 (uint32_t)nrf_radio_task_address_get(
-                                                        NRF_RADIO_TASK_RXEN),
+                                                    NRF_RADIO_TASK_RXEN),
                                                 (uint32_t)nrf_ppi_task_address_get(
-                                                        PPI_CHGRP0_DIS_TASK));
+                                                    PPI_CHGRP0_DIS_TASK));
 
         nrf_egu_event_clear(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT);
 
@@ -2343,7 +2345,7 @@ static void irq_end_state_rx_ack(void)
 
     if (ack_match)
     {
-        p_ack_buffer = mp_current_rx_buffer;
+        p_ack_buffer               = mp_current_rx_buffer;
         mp_current_rx_buffer->free = false;
     }
 
@@ -2353,9 +2355,9 @@ static void irq_end_state_rx_ack(void)
 
     if (ack_match)
     {
-        transmitted_frame_notify(p_ack_buffer->psdu,            // psdu
-                                 rssi_last_measurement_get(),   // rssi
-                                 lqi_get(p_ack_buffer->psdu));  // lqi;
+        transmitted_frame_notify(p_ack_buffer->psdu,           // psdu
+                                 rssi_last_measurement_get(),  // rssi
+                                 lqi_get(p_ack_buffer->psdu)); // lqi;
     }
     else
     {
@@ -2402,7 +2404,8 @@ static void irq_ccabusy_state_cca(void)
 static void irq_edend_state_ed(void)
 {
     uint32_t result = nrf_radio_ed_sample_get();
-    m_ed_result     = result > m_ed_result ? result : m_ed_result;
+
+    m_ed_result = result > m_ed_result ? result : m_ed_result;
 
     if (m_ed_time_left)
     {
@@ -2533,8 +2536,8 @@ static void irq_handler(void)
         switch (m_state)
         {
             case RADIO_STATE_TX_ACK:
-                 irq_phyend_state_tx_ack();
-                 break;
+                irq_phyend_state_tx_ack();
+                break;
 
             case RADIO_STATE_CCA_TX:
             case RADIO_STATE_TX:
@@ -2670,7 +2673,6 @@ static void irq_handler(void)
     nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_IRQ_HANDLER);
 }
 
-
 /***************************************************************************************************
  * @section API functions
  **************************************************************************************************/
@@ -2678,6 +2680,7 @@ static void irq_handler(void)
 void nrf_802154_core_init(void)
 {
     const uint8_t ack_psdu[] = {0x05, ACK_HEADER_WITH_PENDING, 0x00, 0x00, 0x00, 0x00};
+
     memcpy(m_ack_psdu, ack_psdu, sizeof(ack_psdu));
 
     m_state                    = RADIO_STATE_SLEEP;
@@ -2692,10 +2695,10 @@ void nrf_802154_core_deinit(void)
     {
         nrf_radio_reset();
     }
-    
+
     nrf_fem_control_pin_clear();
     nrf_fem_control_deactivate();
-    
+
     irq_deinit();
 }
 
@@ -2965,7 +2968,8 @@ bool nrf_802154_core_channel_update(void)
                     channel_set(nrf_802154_pib_channel_get());
                 }
 
-                term_result = current_operation_terminate(NRF_802154_TERM_NONE, REQ_ORIG_CORE, true);
+                term_result =
+                    current_operation_terminate(NRF_802154_TERM_NONE, REQ_ORIG_CORE, true);
 
                 if (term_result)
                 {
@@ -3030,7 +3034,7 @@ bool nrf_802154_core_cca_cfg_update(void)
 void RADIO_IRQHandler(void)
 #else // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 void nrf_802154_core_irq_handler(void)
-#endif // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
+#endif  // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 {
     irq_handler();
 }

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -76,19 +76,19 @@
 #define PPI_CH5                    NRF_PPI_CHANNEL11
 #define PPI_CH6                    NRF_PPI_CHANNEL12
 #define PPI_CHGRP0                 NRF_PPI_CHANNEL_GROUP0 ///< PPI group used to disable self-disabling PPIs
-#define PPI_CHGRP0_DIS_TASK        NRF_PPI_TASK_CHG0_DIS
+#define PPI_CHGRP0_DIS_TASK        NRF_PPI_TASK_CHG0_DIS  ///< PPI task used to disable self-disabling PPIs
 
-#define PPI_DISABLED_EGU           PPI_CH0 ///< PPI that connects RADIO DISABLED event with EGU task
-#define PPI_EGU_RAMP_UP            PPI_CH1 ///< PPI that connects EGU event with RADIO TXEN or RXEN task
-#define PPI_EGU_TIMER_START        PPI_CH2 ///< PPI that connects EGU event with TIMER START task
-#define PPI_CRCERROR_CLEAR         PPI_CH3 ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
-#define PPI_CCAIDLE_FEM            PPI_CH3 ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
-#define PPI_TIMER_TX_ACK           PPI_CH3 ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
-#define PPI_CRCOK_DIS_PPI          PPI_CH4 ///< PPI that connects RADIO CRCOK event with task that disables PPI group
+#define PPI_DISABLED_EGU           PPI_CH0                ///< PPI that connects RADIO DISABLED event with EGU task
+#define PPI_EGU_RAMP_UP            PPI_CH1                ///< PPI that connects EGU event with RADIO TXEN or RXEN task
+#define PPI_EGU_TIMER_START        PPI_CH2                ///< PPI that connects EGU event with TIMER START task
+#define PPI_CRCERROR_CLEAR         PPI_CH3                ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#define PPI_CCAIDLE_FEM            PPI_CH3                ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
+#define PPI_TIMER_TX_ACK           PPI_CH3                ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
+#define PPI_CRCOK_DIS_PPI          PPI_CH4                ///< PPI that connects RADIO CRCOK event with task that disables PPI group
 
 #if NRF_802154_DISABLE_BCC_MATCHING
-#define PPI_ADDRESS_COUNTER_COUNT  PPI_CH5 ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
-#define PPI_CRCERROR_COUNTER_CLEAR PPI_CH6 ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#define PPI_ADDRESS_COUNTER_COUNT  PPI_CH5                ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
+#define PPI_CRCERROR_COUNTER_CLEAR PPI_CH6                ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
 #endif  // NRF_802154_DISABLE_BCC_MATCHING
 
 /// Workaround for missing PHYEND event in older chip revision.
@@ -170,9 +170,11 @@ static inline uint32_t short_phyend_disable_mask_get(void)
 #if NRF_802154_RX_BUFFERS > 1
 /// Pointer to currently used receive buffer.
 static rx_buffer_t * mp_current_rx_buffer;
+
 #else
 /// If there is only one buffer use const pointer to the receive buffer.
 static rx_buffer_t * const mp_current_rx_buffer = &nrf_802154_rx_buffers[0];
+
 #endif
 
 static uint8_t         m_ack_psdu[IMM_ACK_LENGTH + 1]; ///< ACK frame buffer.
@@ -186,11 +188,14 @@ typedef struct
 {
     bool frame_filtered        : 1; ///< If frame being received passed filtering operation.
     bool rx_timeslot_requested : 1; ///< If timeslot for the frame being received is already requested.
+
 #if !NRF_802154_DISABLE_BCC_MATCHING
-    bool psdu_being_received : 1;   ///< If PSDU is currently being received.
+    bool psdu_being_received   : 1; ///< If PSDU is currently being received.
+
 #endif  // !NRF_802154_DISABLE_BCC_MATCHING
 #if NRF_802154_TX_STARTED_NOTIFY_ENABLED
     bool tx_started : 1; ///< If requested transmission has started.
+
 #endif  // NRF_802154_TX_STARTED_NOTIFY_ENABLED
 } nrf_802154_flags_t;
 static nrf_802154_flags_t m_flags;               ///< Flags used to store current driver state.

--- a/src/nrf_802154_core.h
+++ b/src/nrf_802154_core.h
@@ -54,23 +54,23 @@ extern "C" {
 typedef enum
 {
     // Sleep
-    RADIO_STATE_SLEEP,          ///< Low power (DISABLED) mode - the only state in which all radio preconditions ane not requested.
-    RADIO_STATE_FALLING_ASLEEP, ///< Prior entering SLEEP state all radio preconditions are requested.
+    RADIO_STATE_SLEEP,              ///< Low power (DISABLED) mode - the only state in which all radio preconditions ane not requested.
+    RADIO_STATE_FALLING_ASLEEP,     ///< Prior entering SLEEP state all radio preconditions are requested.
 
     // Receive
-    RADIO_STATE_RX,     ///< Receiver is enabled and it is receiving frames.
-    RADIO_STATE_TX_ACK, ///< Received frame and transmitting ACK.
+    RADIO_STATE_RX,                 ///< Receiver is enabled and it is receiving frames.
+    RADIO_STATE_TX_ACK,             ///< Received frame and transmitting ACK.
 
     // Transmit
-    RADIO_STATE_CCA_TX, ///< Performing CCA followed by frame transmission.
-    RADIO_STATE_TX,     ///< Transmitting data frame (or beacon).
-    RADIO_STATE_RX_ACK, ///< Receiving ACK after transmitted frame.
+    RADIO_STATE_CCA_TX,             ///< Performing CCA followed by frame transmission.
+    RADIO_STATE_TX,                 ///< Transmitting data frame (or beacon).
+    RADIO_STATE_RX_ACK,             ///< Receiving ACK after transmitted frame.
 
     // Energy Detection
-    RADIO_STATE_ED, ///< Performing Energy Detection procedure.
+    RADIO_STATE_ED,                 ///< Performing Energy Detection procedure.
 
     // CCA
-    RADIO_STATE_CCA, ///< Performing CCA procedure.
+    RADIO_STATE_CCA,                ///< Performing CCA procedure.
 
     // Continuous carrier
     RADIO_STATE_CONTINUOUS_CARRIER, ///< Emitting continuous carrier wave.

--- a/src/nrf_802154_core.h
+++ b/src/nrf_802154_core.h
@@ -54,23 +54,23 @@ extern "C" {
 typedef enum
 {
     // Sleep
-    RADIO_STATE_SLEEP,              ///< Low power (DISABLED) mode - the only state in which all radio preconditions ane not requested.
-    RADIO_STATE_FALLING_ASLEEP,     ///< Prior entering SLEEP state all radio preconditions are requested.
+    RADIO_STATE_SLEEP,          ///< Low power (DISABLED) mode - the only state in which all radio preconditions ane not requested.
+    RADIO_STATE_FALLING_ASLEEP, ///< Prior entering SLEEP state all radio preconditions are requested.
 
     // Receive
-    RADIO_STATE_RX,                 ///< Receiver is enabled and it is receiving frames.
-    RADIO_STATE_TX_ACK,             ///< Received frame and transmitting ACK.
+    RADIO_STATE_RX,     ///< Receiver is enabled and it is receiving frames.
+    RADIO_STATE_TX_ACK, ///< Received frame and transmitting ACK.
 
     // Transmit
-    RADIO_STATE_CCA_TX,             ///< Performing CCA followed by frame transmission.
-    RADIO_STATE_TX,                 ///< Transmitting data frame (or beacon).
-    RADIO_STATE_RX_ACK,             ///< Receiving ACK after transmitted frame.
+    RADIO_STATE_CCA_TX, ///< Performing CCA followed by frame transmission.
+    RADIO_STATE_TX,     ///< Transmitting data frame (or beacon).
+    RADIO_STATE_RX_ACK, ///< Receiving ACK after transmitted frame.
 
     // Energy Detection
-    RADIO_STATE_ED,                 ///< Performing Energy Detection procedure.
+    RADIO_STATE_ED, ///< Performing Energy Detection procedure.
 
     // CCA
-    RADIO_STATE_CCA,                ///< Performing CCA procedure.
+    RADIO_STATE_CCA, ///< Performing CCA procedure.
 
     // Continuous carrier
     RADIO_STATE_CONTINUOUS_CARRIER, ///< Emitting continuous carrier wave.
@@ -239,4 +239,3 @@ void nrf_802154_core_irq_handler(void);
 #endif
 
 #endif /* NRF_802154_CORE_H_ */
-

--- a/src/nrf_802154_core_hooks.c
+++ b/src/nrf_802154_core_hooks.c
@@ -46,7 +46,6 @@
 #include "nrf_802154_config.h"
 #include "nrf_802154_types.h"
 
-
 typedef bool (* abort_hook)(nrf_802154_term_t term_lvl, req_originator_t req_orig);
 typedef void (* transmitted_hook)(const uint8_t * p_frame);
 typedef bool (* tx_failed_hook)(const uint8_t * p_frame, nrf_802154_tx_error_t error);

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -47,15 +47,13 @@
 
 #include <nrf.h>
 
-#define CMSIS_IRQ_NUM_VECTACTIVE_DIFF 16
+#define CMSIS_IRQ_NUM_VECTACTIVE_DIFF                 16
 
 #define NESTED_CRITICAL_SECTION_ALLOWED_PRIORITY_NONE (-1)
 
-static volatile uint8_t m_critical_section_monitor;                  ///< Monitors each critical section enter operation
-static volatile uint8_t m_nested_critical_section_counter;           ///< Counter of nested critical sections
-static volatile int8_t  m_nested_critical_section_allowed_priority;  ///< Indicator if nested critical sections are currently allowed
-
-
+static volatile uint8_t m_critical_section_monitor;                 ///< Monitors each critical section enter operation
+static volatile uint8_t m_nested_critical_section_counter;          ///< Counter of nested critical sections
+static volatile int8_t  m_nested_critical_section_allowed_priority; ///< Indicator if nested critical sections are currently allowed
 
 /***************************************************************************************************
  * @section Critical sections management
@@ -106,8 +104,8 @@ static int8_t active_priority_convert(uint32_t active_priority)
 static bool nested_critical_section_is_allowed_in_this_context(void)
 {
     return m_nested_critical_section_allowed_priority ==
-            active_priority_convert(
-                    nrf_802154_critical_section_active_vector_priority_get());
+           active_priority_convert(
+        nrf_802154_critical_section_active_vector_priority_get());
 }
 
 static bool critical_section_enter(bool forced)
@@ -247,11 +245,11 @@ void nrf_802154_critical_section_exit(void)
 void nrf_802154_critical_section_nesting_allow(void)
 {
     assert(m_nested_critical_section_allowed_priority ==
-            NESTED_CRITICAL_SECTION_ALLOWED_PRIORITY_NONE);
+           NESTED_CRITICAL_SECTION_ALLOWED_PRIORITY_NONE);
     assert(m_nested_critical_section_counter >= 1);
 
     m_nested_critical_section_allowed_priority = active_priority_convert(
-            nrf_802154_critical_section_active_vector_priority_get());
+        nrf_802154_critical_section_active_vector_priority_get());
 }
 
 void nrf_802154_critical_section_nesting_deny(void)
@@ -286,4 +284,3 @@ uint32_t nrf_802154_critical_section_active_vector_priority_get(void)
 
     return active_priority;
 }
-

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -104,8 +104,7 @@ static int8_t active_priority_convert(uint32_t active_priority)
 static bool nested_critical_section_is_allowed_in_this_context(void)
 {
     return m_nested_critical_section_allowed_priority ==
-           active_priority_convert(
-        nrf_802154_critical_section_active_vector_priority_get());
+           active_priority_convert(nrf_802154_critical_section_active_vector_priority_get());
 }
 
 static bool critical_section_enter(bool forced)

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -48,6 +48,7 @@
 volatile uint32_t nrf_802154_debug_log_buffer[NRF_802154_DEBUG_LOG_BUFFER_LEN];
 /// Index of the log buffer pointing to the element that should be filled with next log message.
 volatile uint32_t nrf_802154_debug_log_ptr = 0;
+
 #endif
 
 #if ENABLE_DEBUG_GPIO

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -63,12 +63,30 @@ static void radio_event_gpio_toggle_init(void)
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_EDEND);
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_PHYEND);
 
-    nrf_gpiote_task_configure(0, PIN_DBG_RADIO_EVT_END, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(1, PIN_DBG_RADIO_EVT_DISABLED, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(2, PIN_DBG_RADIO_EVT_READY, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(3, PIN_DBG_RADIO_EVT_FRAMESTART, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(4, PIN_DBG_RADIO_EVT_EDEND, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(5, PIN_DBG_RADIO_EVT_PHYEND, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(0,
+                              PIN_DBG_RADIO_EVT_END,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(1,
+                              PIN_DBG_RADIO_EVT_DISABLED,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(2,
+                              PIN_DBG_RADIO_EVT_READY,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(3,
+                              PIN_DBG_RADIO_EVT_FRAMESTART,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(4,
+                              PIN_DBG_RADIO_EVT_EDEND,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(5,
+                              PIN_DBG_RADIO_EVT_PHYEND,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
 
     nrf_gpiote_task_enable(0);
     nrf_gpiote_task_enable(1);
@@ -77,12 +95,24 @@ static void radio_event_gpio_toggle_init(void)
     nrf_gpiote_task_enable(4);
     nrf_gpiote_task_enable(5);
 
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0, (uint32_t) &NRF_RADIO->EVENTS_END,        nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_0));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL1, (uint32_t) &NRF_RADIO->EVENTS_DISABLED,   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_1));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL2, (uint32_t) &NRF_RADIO->EVENTS_READY,      nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_2));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL3, (uint32_t) &NRF_RADIO->EVENTS_FRAMESTART, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL4, (uint32_t) &NRF_RADIO->EVENTS_EDEND,      nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_4));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5, (uint32_t) &NRF_RADIO->EVENTS_PHYEND,     nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0,
+                                   (uint32_t)&NRF_RADIO->EVENTS_END,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_0));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL1,
+                                   (uint32_t)&NRF_RADIO->EVENTS_DISABLED,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_1));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL2,
+                                   (uint32_t)&NRF_RADIO->EVENTS_READY,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_2));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL3,
+                                   (uint32_t)&NRF_RADIO->EVENTS_FRAMESTART,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL4,
+                                   (uint32_t)&NRF_RADIO->EVENTS_EDEND,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_4));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5,
+                                   (uint32_t)&NRF_RADIO->EVENTS_PHYEND,
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
 
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL0);
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL1);
@@ -118,15 +148,21 @@ static void raal_softdevice_event_gpio_toggle_init(void)
     nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_BLOCKED);
     nrf_gpio_cfg_output(PIN_DBG_RTC0_EVT_REM);
 
-    nrf_gpiote_task_configure(5, PIN_DBG_RTC0_EVT_REM, NRF_GPIOTE_POLARITY_TOGGLE, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+    nrf_gpiote_task_configure(5,
+                              PIN_DBG_RTC0_EVT_REM,
+                              NRF_GPIOTE_POLARITY_TOGGLE,
+                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
 
     nrf_gpiote_task_enable(5);
 
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5, (uint32_t) &NRF_RTC0->EVENTS_COMPARE[1], nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
+    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5,
+                                   (uint32_t)&NRF_RTC0->EVENTS_COMPARE[1],
+                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
 
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL5);
 #endif // RAAL_SOFTDEVICE
 }
+
 #endif // ENABLE_DEBUG_GPIO
 
 void nrf_802154_debug_init(void)
@@ -139,15 +175,17 @@ void nrf_802154_debug_init(void)
 }
 
 #if ENABLE_DEBUG_ASSERT
-void __assert_func(const char *file, int line, const char *func, const char *cond)
+void __assert_func(const char * file, int line, const char * func, const char * cond)
 {
-    (void) file;
-    (void) line;
-    (void) func;
-    (void) cond;
+    (void)file;
+    (void)line;
+    (void)func;
+    (void)cond;
 
     __disable_irq();
 
-    while (1);
+    while (1)
+        ;
 }
+
 #endif // ENABLE_DEBUG_ASSERT

--- a/src/nrf_802154_debug.h
+++ b/src/nrf_802154_debug.h
@@ -147,6 +147,7 @@ extern volatile uint32_t nrf_802154_debug_log_ptr;
     do                                                                           \
     {                                                                            \
         uint32_t ptr = nrf_802154_debug_log_ptr;                                 \
+                                                                                 \
         nrf_802154_debug_log_buffer[ptr] = ((EVENT_CODE) | ((EVENT_ARG) << 16)); \
         nrf_802154_debug_log_ptr         =                                       \
             ptr < (NRF_802154_DEBUG_LOG_BUFFER_LEN - 1) ? ptr + 1 : 0;           \
@@ -167,6 +168,7 @@ extern volatile uint32_t nrf_802154_debug_log_ptr;
     do                                           \
     {                                            \
         volatile uint32_t ps = NRF_P0->OUT;      \
+                                                 \
         NRF_P0->OUTSET = (~ps & (1UL << (pin))); \
         NRF_P0->OUTCLR = (ps & (1UL << (pin)));  \
     }                                            \

--- a/src/nrf_802154_debug.h
+++ b/src/nrf_802154_debug.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#define NRF_802154_DEBUG_LOG_BUFFER_LEN 1024
+#define NRF_802154_DEBUG_LOG_BUFFER_LEN        1024
 
 #define EVENT_TRACE_ENTER                      0x0001UL
 #define EVENT_TRACE_EXIT                       0x0002UL
@@ -140,16 +140,18 @@ extern "C" {
 
 #if ENABLE_DEBUG_LOG
 extern volatile uint32_t nrf_802154_debug_log_buffer[
-        NRF_802154_DEBUG_LOG_BUFFER_LEN];
+    NRF_802154_DEBUG_LOG_BUFFER_LEN];
 extern volatile uint32_t nrf_802154_debug_log_ptr;
 
-#define nrf_802154_log(EVENT_CODE, EVENT_ARG)                                                      \
-    do {                                                                                           \
-        uint32_t ptr = nrf_802154_debug_log_ptr;                                                   \
-        nrf_802154_debug_log_buffer[ptr] = ((EVENT_CODE) | ((EVENT_ARG) << 16));                   \
-        nrf_802154_debug_log_ptr =                                                                 \
-                ptr < (NRF_802154_DEBUG_LOG_BUFFER_LEN - 1) ? ptr + 1 : 0;                         \
-    } while (0)
+#define nrf_802154_log(EVENT_CODE, EVENT_ARG)                                    \
+    do                                                                           \
+    {                                                                            \
+        uint32_t ptr = nrf_802154_debug_log_ptr;                                 \
+        nrf_802154_debug_log_buffer[ptr] = ((EVENT_CODE) | ((EVENT_ARG) << 16)); \
+        nrf_802154_debug_log_ptr         =                                       \
+            ptr < (NRF_802154_DEBUG_LOG_BUFFER_LEN - 1) ? ptr + 1 : 0;           \
+    }                                                                            \
+    while (0)
 
 #else // ENABLE_DEBUG_LOG
 
@@ -161,10 +163,14 @@ extern volatile uint32_t nrf_802154_debug_log_ptr;
 
 #define nrf_802154_pin_set(pin) NRF_P0->OUTSET = (1UL << (pin))
 #define nrf_802154_pin_clr(pin) NRF_P0->OUTCLR = (1UL << (pin))
-#define nrf_802154_pin_tgl(pin) do { volatile uint32_t ps = NRF_P0->OUT;                           \
-                                            NRF_P0->OUTSET = (~ps & (1UL << (pin)));               \
-                                            NRF_P0->OUTCLR = (ps & (1UL << (pin)));                \
-                                         } while(0);
+#define nrf_802154_pin_tgl(pin)                  \
+    do                                           \
+    {                                            \
+        volatile uint32_t ps = NRF_P0->OUT;      \
+        NRF_P0->OUTSET = (~ps & (1UL << (pin))); \
+        NRF_P0->OUTCLR = (ps & (1UL << (pin)));  \
+    }                                            \
+    while (0);
 
 #else // ENABLE_DEBUG_GPIO
 

--- a/src/nrf_802154_notification.h
+++ b/src/nrf_802154_notification.h
@@ -55,7 +55,7 @@ extern "C" {
  *
  * @param[in]  result  If called request succeeded.
  */
-typedef void (*nrf_802154_notification_func_t)(bool result);
+typedef void (* nrf_802154_notification_func_t)(bool result);
 
 /**
  * @brief Initialize notification module.

--- a/src/nrf_802154_notification_direct.c
+++ b/src/nrf_802154_notification_direct.c
@@ -56,7 +56,7 @@ void nrf_802154_notify_received(uint8_t * p_data, int8_t power, int8_t lqi)
     nrf_802154_received_raw(p_data, power, lqi);
 #else // NRF_802154_USE_RAW_API
     nrf_802154_received(p_data + RAW_PAYLOAD_OFFSET, p_data[RAW_LENGTH_OFFSET], power, lqi);
-#endif // NRF_802154_USE_RAW_API
+#endif  // NRF_802154_USE_RAW_API
 }
 
 void nrf_802154_notify_receive_failed(nrf_802154_rx_error_t error)
@@ -86,7 +86,7 @@ void nrf_802154_notify_transmit_failed(const uint8_t * p_frame, nrf_802154_tx_er
     nrf_802154_transmit_failed(p_frame, error);
 #else // NRF_802154_USE_RAW_API
     nrf_802154_transmit_failed(p_frame + RAW_PAYLOAD_OFFSET, error);
-#endif // NRF_802154_USE_RAW_API
+#endif  // NRF_802154_USE_RAW_API
 }
 
 void nrf_802154_notify_energy_detected(uint8_t result)

--- a/src/nrf_802154_notification_swi.c
+++ b/src/nrf_802154_notification_swi.c
@@ -89,4 +89,3 @@ void nrf_802154_notify_cca_failed(nrf_802154_cca_error_t error)
 {
     nrf_802154_swi_notify_cca_failed(error);
 }
-

--- a/src/nrf_802154_pib.c
+++ b/src/nrf_802154_pib.c
@@ -46,18 +46,18 @@
 
 typedef struct
 {
-    int8_t               tx_power;                                ///< Transmit power.
-    uint8_t              pan_id[PAN_ID_SIZE];                     ///< Pan Id of this node.
-    uint8_t              short_addr[SHORT_ADDRESS_SIZE];          ///< Short Address of this node.
-    uint8_t              extended_addr[EXTENDED_ADDRESS_SIZE];    ///< Extended Address of this node.
-    nrf_802154_cca_cfg_t cca;                                     ///< CCA mode and thresholds.
-    bool                 promiscuous                          :1; ///< Indicating if radio is in promiscuous mode.
-    bool                 auto_ack                             :1; ///< Indicating if auto ACK procedure is enabled.
-    bool                 pan_coord                            :1; ///< Indicating if radio is configured as the PAN coordinator.
-    uint8_t              channel                              :5; ///< Channel on which the node receives messages.
+    int8_t               tx_power;                             ///< Transmit power.
+    uint8_t              pan_id[PAN_ID_SIZE];                  ///< Pan Id of this node.
+    uint8_t              short_addr[SHORT_ADDRESS_SIZE];       ///< Short Address of this node.
+    uint8_t              extended_addr[EXTENDED_ADDRESS_SIZE]; ///< Extended Address of this node.
+    nrf_802154_cca_cfg_t cca;                                  ///< CCA mode and thresholds.
+    bool                 promiscuous : 1;                      ///< Indicating if radio is in promiscuous mode.
+    bool                 auto_ack    : 1;                      ///< Indicating if auto ACK procedure is enabled.
+    bool                 pan_coord   : 1;                      ///< Indicating if radio is configured as the PAN coordinator.
+    uint8_t              channel     : 5;                      ///< Channel on which the node receives messages.
 } nrf_802154_pib_data_t;
 
-static nrf_802154_pib_data_t m_data;  ///< Buffer containing PIB data.
+static nrf_802154_pib_data_t m_data; ///< Buffer containing PIB data.
 
 void nrf_802154_pib_init(void)
 {
@@ -125,7 +125,9 @@ int8_t nrf_802154_pib_tx_power_get(void)
 void nrf_802154_pib_tx_power_set(int8_t dbm)
 {
     const int8_t allowed_values[] = {-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8};
-    const int8_t highest_value    = allowed_values[(sizeof(allowed_values) / sizeof(allowed_values[0])) - 1];
+    const int8_t highest_value    =
+        allowed_values[(sizeof(allowed_values) / sizeof(allowed_values[0])) - 1];
+
     if (dbm > highest_value)
     {
         dbm = highest_value;

--- a/src/nrf_802154_pib.c
+++ b/src/nrf_802154_pib.c
@@ -57,6 +57,7 @@ typedef struct
     uint8_t              channel     : 5;                      ///< Channel on which the node receives messages.
 } nrf_802154_pib_data_t;
 
+// Static variables.
 static nrf_802154_pib_data_t m_data; ///< Buffer containing PIB data.
 
 void nrf_802154_pib_init(void)

--- a/src/nrf_802154_pib.h
+++ b/src/nrf_802154_pib.h
@@ -95,7 +95,6 @@ bool nrf_802154_pib_pan_coord_get(void);
  */
 void nrf_802154_pib_pan_coord_set(bool enabled);
 
-
 /**
  * @brief Get currently used channel.
  *
@@ -191,4 +190,3 @@ void nrf_802154_pib_cca_cfg_get(nrf_802154_cca_cfg_t * p_cca_cfg);
 #endif
 
 #endif /* NRF_802154_PIB_H_ */
-

--- a/src/nrf_802154_priority_drop.h
+++ b/src/nrf_802154_priority_drop.h
@@ -74,4 +74,3 @@ void nrf_802154_priority_drop_hfclk_stop_terminate(void);
 #endif
 
 #endif // NRF_802154_PRIORITY_DROP_H__
-

--- a/src/nrf_802154_priority_drop_direct.c
+++ b/src/nrf_802154_priority_drop_direct.c
@@ -54,4 +54,3 @@ void nrf_802154_priority_drop_hfclk_stop_terminate(void)
     // Intentionally empty:
     // nrf_802154_priority_drop_hfclk_stop is synchronous and cannot be terminated.
 }
-

--- a/src/nrf_802154_priority_drop_swi.c
+++ b/src/nrf_802154_priority_drop_swi.c
@@ -53,4 +53,3 @@ void nrf_802154_priority_drop_hfclk_stop_terminate(void)
 {
     nrf_802154_swi_hfclk_stop_terminate();
 }
-

--- a/src/nrf_802154_procedures_duration.h
+++ b/src/nrf_802154_procedures_duration.h
@@ -42,25 +42,26 @@
 
 #include "nrf_802154_const.h"
 
-#define TX_RAMP_UP_TIME       40  // us
-#define RX_RAMP_UP_TIME       40  // us
-#define RX_RAMP_DOWN_TIME     0   // us
-#define MAX_RAMP_DOWN_TIME    6   // us
-#define RX_TX_TURNAROUND_TIME 20  // us
+#define TX_RAMP_UP_TIME                   40 // us
+#define RX_RAMP_UP_TIME                   40 // us
+#define RX_RAMP_DOWN_TIME                 0  // us
+#define MAX_RAMP_DOWN_TIME                6  // us
+#define RX_TX_TURNAROUND_TIME             20 // us
 
-#define A_CCA_DURATION_SYMBOLS    8   // sym
-#define A_TURNAROUND_TIME_SYMBOLS 12  // sym
-#define A_UNIT_BACKOFF_SYMBOLS    20  // sym
+#define A_CCA_DURATION_SYMBOLS            8  // sym
+#define A_TURNAROUND_TIME_SYMBOLS         12 // sym
+#define A_UNIT_BACKOFF_SYMBOLS            20 // sym
 
 #define PHY_SYMBOLS_FROM_OCTETS(octets)   ((octets) * PHY_SYMBOLS_PER_OCTET)
 #define PHY_US_TIME_FROM_SYMBOLS(symbols) ((symbols) * PHY_US_PER_SYMBOL)
 
-#define IMM_ACK_SYMBOLS  (PHY_SHR_SYMBOLS + PHY_SYMBOLS_FROM_OCTETS(IMM_ACK_LENGTH + PHR_SIZE))
-#define IMM_ACK_DURATION (PHY_US_TIME_FROM_SYMBOLS(IMM_ACK_SYMBOLS))
+#define IMM_ACK_SYMBOLS                   (PHY_SHR_SYMBOLS + \
+                                           PHY_SYMBOLS_FROM_OCTETS(IMM_ACK_LENGTH + PHR_SIZE))
+#define IMM_ACK_DURATION                  (PHY_US_TIME_FROM_SYMBOLS(IMM_ACK_SYMBOLS))
 
-#define MAC_IMM_ACK_WAIT_SYMBOLS (A_UNIT_BACKOFF_SYMBOLS +    \
-                                  A_TURNAROUND_TIME_SYMBOLS + \
-                                  IMM_ACK_SYMBOLS)
+#define MAC_IMM_ACK_WAIT_SYMBOLS          (A_UNIT_BACKOFF_SYMBOLS +    \
+                                           A_TURNAROUND_TIME_SYMBOLS + \
+                                           IMM_ACK_SYMBOLS)
 
 __STATIC_INLINE uint16_t nrf_802154_tx_duration_get(uint8_t psdu_length,
                                                     bool    cca,
@@ -101,7 +102,10 @@ __STATIC_INLINE uint16_t nrf_802154_tx_duration_get(uint8_t psdu_length,
     // if CCA: + RX ramp up + CCA + RX ramp down
     // + TX ramp up + SHR + PHR + PSDU
     // if ACK: + macAckWaitDuration
-    uint16_t us_time = MAX_RAMP_DOWN_TIME + TX_RAMP_UP_TIME + nrf_802154_frame_duration_get(psdu_length, true, true);
+    uint16_t us_time = MAX_RAMP_DOWN_TIME + TX_RAMP_UP_TIME + nrf_802154_frame_duration_get(
+        psdu_length,
+        true,
+        true);
 
     if (ack_requested)
     {
@@ -110,7 +114,8 @@ __STATIC_INLINE uint16_t nrf_802154_tx_duration_get(uint8_t psdu_length,
 
     if (cca)
     {
-        us_time += RX_RAMP_UP_TIME + RX_RAMP_DOWN_TIME + PHY_US_TIME_FROM_SYMBOLS(A_CCA_DURATION_SYMBOLS);
+        us_time += RX_RAMP_UP_TIME + RX_RAMP_DOWN_TIME + PHY_US_TIME_FROM_SYMBOLS(
+            A_CCA_DURATION_SYMBOLS);
     }
 
     return us_time;

--- a/src/nrf_802154_request_direct.c
+++ b/src/nrf_802154_request_direct.c
@@ -42,13 +42,12 @@
 #include "nrf_802154_core.h"
 #include "hal/nrf_radio.h"
 
-#define REQUEST_FUNCTION(func_core, ...)                                                           \
-    bool result;                                                                                   \
-                                                                                                   \
-    result = func_core(__VA_ARGS__);                                                               \
-                                                                                                   \
+#define REQUEST_FUNCTION(func_core, ...) \
+    bool result;                         \
+                                         \
+    result = func_core(__VA_ARGS__);     \
+                                         \
     return result;
-
 
 void nrf_802154_request_init(void)
 {
@@ -75,7 +74,13 @@ bool nrf_802154_request_transmit(nrf_802154_term_t              term_lvl,
                                  bool                           immediate,
                                  nrf_802154_notification_func_t notify_function)
 {
-    REQUEST_FUNCTION(nrf_802154_core_transmit, term_lvl, req_orig, p_data, cca, immediate, notify_function)
+    REQUEST_FUNCTION(nrf_802154_core_transmit,
+                     term_lvl,
+                     req_orig,
+                     p_data,
+                     cca,
+                     immediate,
+                     notify_function)
 }
 
 bool nrf_802154_request_energy_detection(nrf_802154_term_t term_lvl, uint32_t time_us)

--- a/src/nrf_802154_request_swi.c
+++ b/src/nrf_802154_request_swi.c
@@ -57,34 +57,34 @@ static inline void assert_interrupt_status(void)
     assert(nrf_is_nvic_irq_enabled(NRF_802154_SWI_IRQN));
 }
 
-#define REQUEST_FUNCTION(func_core, func_swi, ...)                                                 \
-    bool result = false;                                                                           \
-                                                                                                   \
-    if (active_vector_priority_is_high())                                                          \
-    {                                                                                              \
-        result = func_core(__VA_ARGS__);                                                           \
-    }                                                                                              \
-    else                                                                                           \
-    {                                                                                              \
-        assert_interrupt_status();                                                                 \
-        func_swi(__VA_ARGS__, &result);                                                            \
-    }                                                                                              \
-                                                                                                   \
+#define REQUEST_FUNCTION(func_core, func_swi, ...) \
+    bool result = false;                           \
+                                                   \
+    if (active_vector_priority_is_high())          \
+    {                                              \
+        result = func_core(__VA_ARGS__);           \
+    }                                              \
+    else                                           \
+    {                                              \
+        assert_interrupt_status();                 \
+        func_swi(__VA_ARGS__, &result);            \
+    }                                              \
+                                                   \
     return result;
 
-#define REQUEST_FUNCTION_NO_ARGS(func_core, func_swi)                                              \
-    bool result = false;                                                                           \
-                                                                                                   \
-    if (active_vector_priority_is_high())                                                          \
-    {                                                                                              \
-        result = func_core();                                                                      \
-    }                                                                                              \
-    else                                                                                           \
-    {                                                                                              \
-        assert_interrupt_status();                                                                 \
-        func_swi(&result);                                                                         \
-    }                                                                                              \
-                                                                                                   \
+#define REQUEST_FUNCTION_NO_ARGS(func_core, func_swi) \
+    bool result = false;                              \
+                                                      \
+    if (active_vector_priority_is_high())             \
+    {                                                 \
+        result = func_core();                         \
+    }                                                 \
+    else                                              \
+    {                                                 \
+        assert_interrupt_status();                    \
+        func_swi(&result);                            \
+    }                                                 \
+                                                      \
     return result;
 
 /** Check if active vector priority is high enough to call requests directly.
@@ -154,7 +154,8 @@ bool nrf_802154_request_cca(nrf_802154_term_t term_lvl)
 
 bool nrf_802154_request_continuous_carrier(nrf_802154_term_t term_lvl)
 {
-    REQUEST_FUNCTION(nrf_802154_core_continuous_carrier, nrf_802154_swi_continuous_carrier, term_lvl)
+    REQUEST_FUNCTION(nrf_802154_core_continuous_carrier, nrf_802154_swi_continuous_carrier,
+                     term_lvl)
 }
 
 bool nrf_802154_request_buffer_free(uint8_t * p_data)
@@ -171,4 +172,3 @@ bool nrf_802154_request_cca_cfg_update(void)
 {
     REQUEST_FUNCTION_NO_ARGS(nrf_802154_core_cca_cfg_update, nrf_802154_swi_cca_cfg_update)
 }
-

--- a/src/nrf_802154_revision.c
+++ b/src/nrf_802154_revision.c
@@ -115,17 +115,17 @@ bool nrf_802154_revision_has_phyend_event(void)
 
     switch (m_nrf52840_revision)
     {
-    case NRF52840_REVISION_AAAA:
-        result = false;
-        break;
+        case NRF52840_REVISION_AAAA:
+            result = false;
+            break;
 
-    case NRF52840_REVISION_AABA:
-    case NRF52840_REVISION_UNKNOWN:
-        result = true;
-        break;
+        case NRF52840_REVISION_AABA:
+        case NRF52840_REVISION_UNKNOWN:
+            result = true;
+            break;
 
-    default:
-        assert(false);
+        default:
+            assert(false);
     }
 
     return result;

--- a/src/nrf_802154_rx_buffer.h
+++ b/src/nrf_802154_rx_buffer.h
@@ -51,7 +51,7 @@ extern "C" {
 typedef struct
 {
     uint8_t psdu[MAX_PACKET_SIZE + 1];
-    bool    free;                      // If this buffer is free or contains a frame.
+    bool    free; // If this buffer is free or contains a frame.
 } rx_buffer_t;
 
 /**
@@ -80,4 +80,3 @@ rx_buffer_t * nrf_802154_rx_buffer_free_find(void);
 #endif
 
 #endif /* NRF_802154_RX_BUFFER_H_ */
-

--- a/src/nrf_802154_swi.c
+++ b/src/nrf_802154_swi.c
@@ -95,6 +95,7 @@ typedef enum
 typedef struct
 {
     nrf_802154_ntf_type_t type; ///< Notification type.
+
     union
     {
         struct
@@ -163,6 +164,7 @@ typedef enum
 typedef struct
 {
     nrf_802154_req_type_t type; ///< Type of the request.
+
     union
     {
         struct
@@ -223,9 +225,9 @@ typedef struct
 
         struct
         {
-            bool * p_result; ///< CCA config update request result.
-        } cca_cfg_update;    ///< CCA config update request details.
-    } data;                  ///< Request data depending on it's type.
+            bool * p_result;                              ///< CCA config update request result.
+        } cca_cfg_update;                                 ///< CCA config update request details.
+    } data;                                               ///< Request data depending on it's type.
 } nrf_802154_req_data_t;
 
 static nrf_802154_ntf_data_t m_ntf_queue[NTF_QUEUE_SIZE]; ///< Notification queue.

--- a/src/nrf_802154_swi.c
+++ b/src/nrf_802154_swi.c
@@ -47,34 +47,33 @@
 #include "hal/nrf_egu.h"
 #include "platform/clock/nrf_802154_clock.h"
 
-
 /** Size of notification queue.
  *
  * One slot for each receive buffer, one for transmission, one for busy channel and one for energy
  * detection.
  */
-#define NTF_QUEUE_SIZE (NRF_802154_RX_BUFFERS + 3)
+#define NTF_QUEUE_SIZE     (NRF_802154_RX_BUFFERS + 3)
 /** Size of requests queue.
  *
  * Two is minimal queue size. It is not expected in current implementation to queue a few requests.
  */
-#define REQ_QUEUE_SIZE 2
+#define REQ_QUEUE_SIZE     2
 
-#define SWI_EGU        NRF_802154_SWI_EGU_INSTANCE    ///< Label of SWI peripheral.
-#define SWI_IRQn       NRF_802154_SWI_IRQN            ///< Symbol of SWI IRQ number.
-#define SWI_IRQHandler NRF_802154_SWI_IRQ_HANDLER     ///< Symbol of SWI IRQ handler.
+#define SWI_EGU            NRF_802154_SWI_EGU_INSTANCE ///< Label of SWI peripheral.
+#define SWI_IRQn           NRF_802154_SWI_IRQN         ///< Symbol of SWI IRQ number.
+#define SWI_IRQHandler     NRF_802154_SWI_IRQ_HANDLER  ///< Symbol of SWI IRQ handler.
 
-#define NTF_INT   NRF_EGU_INT_TRIGGERED0              ///< Label of notification interrupt.
-#define NTF_TASK  NRF_EGU_TASK_TRIGGER0               ///< Label of notification task.
-#define NTF_EVENT NRF_EGU_EVENT_TRIGGERED0            ///< Label of notification event.
+#define NTF_INT            NRF_EGU_INT_TRIGGERED0      ///< Label of notification interrupt.
+#define NTF_TASK           NRF_EGU_TASK_TRIGGER0       ///< Label of notification task.
+#define NTF_EVENT          NRF_EGU_EVENT_TRIGGERED0    ///< Label of notification event.
 
-#define HFCLK_STOP_INT   NRF_EGU_INT_TRIGGERED1       ///< Label of HFClk stop interrupt.
-#define HFCLK_STOP_TASK  NRF_EGU_TASK_TRIGGER1        ///< Label of HFClk stop task.
-#define HFCLK_STOP_EVENT NRF_EGU_EVENT_TRIGGERED1     ///< Label of HFClk stop event.
+#define HFCLK_STOP_INT     NRF_EGU_INT_TRIGGERED1      ///< Label of HFClk stop interrupt.
+#define HFCLK_STOP_TASK    NRF_EGU_TASK_TRIGGER1       ///< Label of HFClk stop task.
+#define HFCLK_STOP_EVENT   NRF_EGU_EVENT_TRIGGERED1    ///< Label of HFClk stop event.
 
-#define REQ_INT   NRF_EGU_INT_TRIGGERED2              ///< Label of request interrupt.
-#define REQ_TASK  NRF_EGU_TASK_TRIGGER2               ///< Label of request task.
-#define REQ_EVENT NRF_EGU_EVENT_TRIGGERED2            ///< Label of request event.
+#define REQ_INT            NRF_EGU_INT_TRIGGERED2      ///< Label of request interrupt.
+#define REQ_TASK           NRF_EGU_TASK_TRIGGER2       ///< Label of request task.
+#define REQ_EVENT          NRF_EGU_EVENT_TRIGGERED2    ///< Label of request event.
 
 #define RAW_LENGTH_OFFSET  0
 #define RAW_PAYLOAD_OFFSET 1
@@ -82,68 +81,68 @@
 /// Types of notifications in notification queue.
 typedef enum
 {
-    NTF_TYPE_RECEIVED,                 ///< Frame received
-    NTF_TYPE_RECEIVE_FAILED,           ///< Frame reception failed
-    NTF_TYPE_TRANSMITTED,              ///< Frame transmitted
-    NTF_TYPE_TRANSMIT_FAILED,          ///< Frame transmission failure
-    NTF_TYPE_ENERGY_DETECTED,          ///< Energy detection procedure ended
-    NTF_TYPE_ENERGY_DETECTION_FAILED,  ///< Energy detection procedure failed
-    NTF_TYPE_CCA,                      ///< CCA procedure ended
-    NTF_TYPE_CCA_FAILED,               ///< CCA procedure failed
+    NTF_TYPE_RECEIVED,                ///< Frame received
+    NTF_TYPE_RECEIVE_FAILED,          ///< Frame reception failed
+    NTF_TYPE_TRANSMITTED,             ///< Frame transmitted
+    NTF_TYPE_TRANSMIT_FAILED,         ///< Frame transmission failure
+    NTF_TYPE_ENERGY_DETECTED,         ///< Energy detection procedure ended
+    NTF_TYPE_ENERGY_DETECTION_FAILED, ///< Energy detection procedure failed
+    NTF_TYPE_CCA,                     ///< CCA procedure ended
+    NTF_TYPE_CCA_FAILED,              ///< CCA procedure failed
 } nrf_802154_ntf_type_t;
 
 /// Notification data in the notification queue.
 typedef struct
 {
-    nrf_802154_ntf_type_t type;  ///< Notification type.
+    nrf_802154_ntf_type_t type; ///< Notification type.
     union
     {
         struct
         {
-            uint8_t              * p_psdu;   ///< Pointer to received frame PSDU.
-            int8_t                 power;    ///< RSSI of received frame.
-            int8_t                 lqi;      ///< LQI of received frame.
-        } received;                          ///< Received frame details.
+            uint8_t * p_psdu; ///< Pointer to received frame PSDU.
+            int8_t    power;  ///< RSSI of received frame.
+            int8_t    lqi;    ///< LQI of received frame.
+        } received;           ///< Received frame details.
 
         struct
         {
-            nrf_802154_rx_error_t  error;    ///< An error code that indicates reason of the failure.
+            nrf_802154_rx_error_t error; ///< An error code that indicates reason of the failure.
         } receive_failed;
 
         struct
         {
-            const uint8_t        * p_frame;  ///< Pointer to frame that was transmitted.
-            uint8_t              * p_psdu;   ///< Pointer to received ACK PSDU or NULL.
-            int8_t                 power;    ///< RSSI of received ACK or 0.
-            int8_t                 lqi;      ///< LQI of received ACK or 0.
-        } transmitted;                       ///< Transmitted frame details.
+            const uint8_t * p_frame; ///< Pointer to frame that was transmitted.
+            uint8_t       * p_psdu;  ///< Pointer to received ACK PSDU or NULL.
+            int8_t          power;   ///< RSSI of received ACK or 0.
+            int8_t          lqi;     ///< LQI of received ACK or 0.
+        } transmitted;               ///< Transmitted frame details.
 
         struct
         {
-            const uint8_t        * p_frame;  ///< Pointer to frame that was requested to be transmitted, but failed.
-            nrf_802154_tx_error_t  error;    ///< An error code that indicates reason of the failure.
+            const uint8_t       * p_frame; ///< Pointer to frame that was requested to be transmitted, but failed.
+            nrf_802154_tx_error_t error;   ///< An error code that indicates reason of the failure.
         } transmit_failed;
 
         struct
         {
-            int8_t                 result;   ///< Energy detection result.
-        } energy_detected;                   ///< Energy detection details.
+            int8_t result; ///< Energy detection result.
+        } energy_detected; ///< Energy detection details.
 
         struct
         {
-            nrf_802154_ed_error_t  error;    ///< An error code that indicates reason of the failure.
-        } energy_detection_failed;           ///< Energy detection failure details.
+            nrf_802154_ed_error_t error; ///< An error code that indicates reason of the failure.
+        } energy_detection_failed;       ///< Energy detection failure details.
 
         struct
         {
-            bool                   result;   ///< CCA result.
-        } cca;                               ///< CCA details.
+            bool result; ///< CCA result.
+        } cca;           ///< CCA details.
 
         struct
         {
-            nrf_802154_cca_error_t error;    ///< An error code that indicates reason of the failure.
-        } cca_failed;                        ///< CCA failure details.
-    } data;                                  ///< Notification data depending on it's type.
+            nrf_802154_cca_error_t error; ///< An error code that indicates reason of the failure.
+        } cca_failed;                     ///< CCA failure details.
+    } data;                               ///< Notification data depending on it's type.
 } nrf_802154_ntf_data_t;
 
 /// Type of requests in request queue.
@@ -163,79 +162,79 @@ typedef enum
 /// Request data in request queue.
 typedef struct
 {
-    nrf_802154_req_type_t type;  ///< Type of the request.
+    nrf_802154_req_type_t type; ///< Type of the request.
     union
     {
         struct
         {
-            nrf_802154_term_t term_lvl;                  ///< Request priority.
-            bool            * p_result;                  ///< Sleep request result.
-        } sleep;                                         ///< Sleep request details.
+            nrf_802154_term_t term_lvl; ///< Request priority.
+            bool            * p_result; ///< Sleep request result.
+        } sleep;                        ///< Sleep request details.
 
         struct
         {
-            nrf_802154_notification_func_t notif_func;   ///< Error notified in case of success.
-            nrf_802154_term_t              term_lvl;     ///< Request priority.
-            req_originator_t               req_orig;     ///< Request originator.
-            bool                           notif_abort;  ///< If function termination should be notified.
-            bool                         * p_result;     ///< Receive request result.
-        } receive;                                       ///< Receive request details.
+            nrf_802154_notification_func_t notif_func;  ///< Error notified in case of success.
+            nrf_802154_term_t              term_lvl;    ///< Request priority.
+            req_originator_t               req_orig;    ///< Request originator.
+            bool                           notif_abort; ///< If function termination should be notified.
+            bool                         * p_result;    ///< Receive request result.
+        } receive;                                      ///< Receive request details.
 
         struct
         {
-            nrf_802154_notification_func_t notif_func;   ///< Error notified in case of success.
-            nrf_802154_term_t              term_lvl;     ///< Request priority.
-            req_originator_t               req_orig;     ///< Request originator.
-            const uint8_t                * p_data;       ///< Pointer to PSDU to transmit.
-            bool                           cca;          ///< If CCA was requested prior to transmission.
-            bool                           immediate;    ///< If TX procedure must be performed immediately.
-            bool                         * p_result;     ///< Transmit request result.
-        } transmit;                                      ///< Transmit request details.
+            nrf_802154_notification_func_t notif_func; ///< Error notified in case of success.
+            nrf_802154_term_t              term_lvl;   ///< Request priority.
+            req_originator_t               req_orig;   ///< Request originator.
+            const uint8_t                * p_data;     ///< Pointer to PSDU to transmit.
+            bool                           cca;        ///< If CCA was requested prior to transmission.
+            bool                           immediate;  ///< If TX procedure must be performed immediately.
+            bool                         * p_result;   ///< Transmit request result.
+        } transmit;                                    ///< Transmit request details.
 
         struct
         {
-            nrf_802154_term_t term_lvl;                  ///< Request priority.
-            bool            * p_result;                  ///< Energy detection request result.
-            uint32_t          time_us;                   ///< Requested time of energy detection procedure.
-        } energy_detection;                              ///< Energy detection request details.
+            nrf_802154_term_t term_lvl; ///< Request priority.
+            bool            * p_result; ///< Energy detection request result.
+            uint32_t          time_us;  ///< Requested time of energy detection procedure.
+        } energy_detection;             ///< Energy detection request details.
 
         struct
         {
-            nrf_802154_term_t term_lvl;                  ///< Request priority.
-            bool            * p_result;                  ///< CCA request result.
-        } cca;                                           ///< CCA request details.
+            nrf_802154_term_t term_lvl; ///< Request priority.
+            bool            * p_result; ///< CCA request result.
+        } cca;                          ///< CCA request details.
 
         struct
         {
-            nrf_802154_term_t term_lvl;                  ///< Request priority.
-            bool            * p_result;                  ///< Continuous carrier request result.
-        } continuous_carrier;                            ///< Continuous carrier request details.
+            nrf_802154_term_t term_lvl; ///< Request priority.
+            bool            * p_result; ///< Continuous carrier request result.
+        } continuous_carrier;           ///< Continuous carrier request details.
 
         struct
         {
-            uint8_t * p_data;                            ///< Pointer to receive buffer to free.
-            bool    * p_result;                          ///< Buffer free request result.
-        } buffer_free;                                   ///< Buffer free request details.
+            uint8_t * p_data;   ///< Pointer to receive buffer to free.
+            bool    * p_result; ///< Buffer free request result.
+        } buffer_free;          ///< Buffer free request details.
 
         struct
         {
-            bool * p_result;                             ///< Channel update request result.
-        } channel_update;                                ///< Channel update request details.
+            bool * p_result; ///< Channel update request result.
+        } channel_update;    ///< Channel update request details.
 
         struct
         {
-            bool * p_result;                             ///< CCA config update request result.
-        } cca_cfg_update;                                ///< CCA config update request details.
-    } data;                                              ///< Request data depending on it's type.
+            bool * p_result; ///< CCA config update request result.
+        } cca_cfg_update;    ///< CCA config update request details.
+    } data;                  ///< Request data depending on it's type.
 } nrf_802154_req_data_t;
 
-static nrf_802154_ntf_data_t m_ntf_queue[NTF_QUEUE_SIZE];  ///< Notification queue.
-static uint8_t               m_ntf_r_ptr;                  ///< Notification queue read index.
-static uint8_t               m_ntf_w_ptr;                  ///< Notification queue write index.
+static nrf_802154_ntf_data_t m_ntf_queue[NTF_QUEUE_SIZE]; ///< Notification queue.
+static uint8_t               m_ntf_r_ptr;                 ///< Notification queue read index.
+static uint8_t               m_ntf_w_ptr;                 ///< Notification queue write index.
 
-static nrf_802154_req_data_t m_req_queue[REQ_QUEUE_SIZE];  ///< Request queue.
-static uint8_t               m_req_r_ptr;                  ///< Request queue read index.
-static uint8_t               m_req_w_ptr;                  ///< Request queue write index.
+static nrf_802154_req_data_t m_req_queue[REQ_QUEUE_SIZE]; ///< Request queue.
+static uint8_t               m_req_r_ptr;                 ///< Request queue read index.
+static uint8_t               m_req_w_ptr;                 ///< Request queue write index.
 
 /**
  * Increment given index for any queue.
@@ -431,7 +430,7 @@ void nrf_802154_swi_init(void)
     m_ntf_r_ptr = 0;
     m_ntf_w_ptr = 0;
 
-    nrf_egu_int_enable(SWI_EGU, NTF_INT | HFCLK_STOP_INT |  REQ_INT);
+    nrf_egu_int_enable(SWI_EGU, NTF_INT | HFCLK_STOP_INT | REQ_INT);
 
     NVIC_SetPriority(SWI_IRQn, NRF_802154_SWI_PRIORITY);
     NVIC_ClearPendingIRQ(SWI_IRQn);
@@ -695,7 +694,7 @@ void SWI_IRQHandler(void)
 #else // NRF_802154_USE_RAW_API
                     nrf_802154_transmitted(p_slot->data.transmitted.p_frame + RAW_PAYLOAD_OFFSET,
                                            p_slot->data.transmitted.p_psdu == NULL ? NULL :
-                                               p_slot->data.transmitted.p_psdu + RAW_PAYLOAD_OFFSET,
+                                           p_slot->data.transmitted.p_psdu + RAW_PAYLOAD_OFFSET,
                                            p_slot->data.transmitted.p_psdu[RAW_LENGTH_OFFSET],
                                            p_slot->data.transmitted.power,
                                            p_slot->data.transmitted.lqi);
@@ -707,8 +706,9 @@ void SWI_IRQHandler(void)
                     nrf_802154_transmit_failed(p_slot->data.transmit_failed.p_frame,
                                                p_slot->data.transmit_failed.error);
 #else // NRF_802154_USE_RAW_API
-                    nrf_802154_transmit_failed(p_slot->data.transmit_failed.p_frame + RAW_PAYLOAD_OFFSET,
-                                               p_slot->data.transmit_failed.error);
+                    nrf_802154_transmit_failed(
+                        p_slot->data.transmit_failed.p_frame + RAW_PAYLOAD_OFFSET,
+                        p_slot->data.transmit_failed.error);
 #endif
                     break;
 
@@ -718,7 +718,7 @@ void SWI_IRQHandler(void)
 
                 case NTF_TYPE_ENERGY_DETECTION_FAILED:
                     nrf_802154_energy_detection_failed(
-                            p_slot->data.energy_detection_failed.error);
+                        p_slot->data.energy_detection_failed.error);
                     break;
 
                 case NTF_TYPE_CCA:
@@ -756,32 +756,32 @@ void SWI_IRQHandler(void)
             {
                 case REQ_TYPE_SLEEP:
                     *(p_slot->data.sleep.p_result) =
-                            nrf_802154_core_sleep(p_slot->data.sleep.term_lvl);
+                        nrf_802154_core_sleep(p_slot->data.sleep.term_lvl);
                     break;
 
                 case REQ_TYPE_RECEIVE:
                     *(p_slot->data.receive.p_result) =
-                            nrf_802154_core_receive(p_slot->data.receive.term_lvl,
-                                                    p_slot->data.receive.req_orig,
-                                                    p_slot->data.receive.notif_func,
-                                                    p_slot->data.receive.notif_abort);
+                        nrf_802154_core_receive(p_slot->data.receive.term_lvl,
+                                                p_slot->data.receive.req_orig,
+                                                p_slot->data.receive.notif_func,
+                                                p_slot->data.receive.notif_abort);
                     break;
 
                 case REQ_TYPE_TRANSMIT:
                     *(p_slot->data.transmit.p_result) =
-                            nrf_802154_core_transmit(p_slot->data.transmit.term_lvl,
-                                                     p_slot->data.transmit.req_orig,
-                                                     p_slot->data.transmit.p_data,
-                                                     p_slot->data.transmit.cca,
-                                                     p_slot->data.transmit.immediate,
-                                                     p_slot->data.transmit.notif_func);
+                        nrf_802154_core_transmit(p_slot->data.transmit.term_lvl,
+                                                 p_slot->data.transmit.req_orig,
+                                                 p_slot->data.transmit.p_data,
+                                                 p_slot->data.transmit.cca,
+                                                 p_slot->data.transmit.immediate,
+                                                 p_slot->data.transmit.notif_func);
                     break;
 
                 case REQ_TYPE_ENERGY_DETECTION:
                     *(p_slot->data.energy_detection.p_result) =
-                            nrf_802154_core_energy_detection(
-                                    p_slot->data.energy_detection.term_lvl,
-                                    p_slot->data.energy_detection.time_us);
+                        nrf_802154_core_energy_detection(
+                            p_slot->data.energy_detection.term_lvl,
+                            p_slot->data.energy_detection.time_us);
                     break;
 
                 case REQ_TYPE_CCA:
@@ -790,13 +790,13 @@ void SWI_IRQHandler(void)
 
                 case REQ_TYPE_CONTINUOUS_CARRIER:
                     *(p_slot->data.continuous_carrier.p_result) =
-                            nrf_802154_core_continuous_carrier(
-                                    p_slot->data.continuous_carrier.term_lvl);
+                        nrf_802154_core_continuous_carrier(
+                            p_slot->data.continuous_carrier.term_lvl);
                     break;
 
                 case REQ_TYPE_BUFFER_FREE:
                     *(p_slot->data.buffer_free.p_result) =
-                            nrf_802154_core_notify_buffer_free(p_slot->data.buffer_free.p_data);
+                        nrf_802154_core_notify_buffer_free(p_slot->data.buffer_free.p_data);
                     break;
 
                 case REQ_TYPE_CHANNEL_UPDATE:

--- a/src/nrf_802154_timer_coord.c
+++ b/src/nrf_802154_timer_coord.c
@@ -47,9 +47,8 @@
 
 #define DIV_ROUND_POSITIVE(n, d) (((n) + (d) / 2) / (d))
 #define DIV_ROUND_NEGATIVE(n, d) (((n) - (d) / 2) / (d))
-#define DIV_ROUND(n,                                                                \
-                  d)             ((((n) < 0) ^ ((d) < 0)) ? DIV_ROUND_NEGATIVE(n,   \
-                                                                               d) : \
+#define DIV_ROUND(n, d)          ((((n) < 0) ^ ((d) < 0)) ?  \
+                                  DIV_ROUND_NEGATIVE(n, d) : \
                                   DIV_ROUND_POSITIVE(n, d))
 
 #define TIME_BASE                (1UL << 22)      ///< Unit used to calculate PPTB (Point per Time Base). It is not equal million to speed up computations and increase precision.
@@ -73,6 +72,7 @@ typedef struct
     uint32_t hp_timer_time; ///< HP Timer time of common timepoint.
 } common_timepoint_t;
 
+// Static variables.
 static common_timepoint_t m_last_sync;    ///< Common timepoint of last synchronization event.
 static volatile bool      m_synchronized; ///< If timers were synchronized since last start.
 static bool               m_drift_known;  ///< If timer drift value is known.

--- a/src/nrf_802154_timer_coord.c
+++ b/src/nrf_802154_timer_coord.c
@@ -45,23 +45,25 @@
 #include "platform/hp_timer/nrf_802154_hp_timer.h"
 #include "platform/lp_timer/nrf_802154_lp_timer.h"
 
-#define DIV_ROUND_POSITIVE(n, d) (((n) + (d)/2)/(d))
-#define DIV_ROUND_NEGATIVE(n, d) (((n) - (d)/2)/(d))
-#define DIV_ROUND(n, d) ((((n) < 0) ^ ((d) < 0)) ? DIV_ROUND_NEGATIVE(n, d) : DIV_ROUND_POSITIVE(n, d))
+#define DIV_ROUND_POSITIVE(n, d) (((n) + (d) / 2) / (d))
+#define DIV_ROUND_NEGATIVE(n, d) (((n) - (d) / 2) / (d))
+#define DIV_ROUND(n,                                                                \
+                  d)             ((((n) < 0) ^ ((d) < 0)) ? DIV_ROUND_NEGATIVE(n,   \
+                                                                               d) : \
+                                  DIV_ROUND_POSITIVE(n, d))
 
+#define TIME_BASE                (1UL << 22)      ///< Unit used to calculate PPTB (Point per Time Base). It is not equal million to speed up computations and increase precision.
+#define FIRST_RESYNC_TIME        TIME_BASE        ///< Delay of the first resynchronization. The first resynchronization is needed to measure timers drift.
+#define RESYNC_TIME              (64 * TIME_BASE) ///< Delay of following resynchronizations.
+#define EWMA_COEF                (8)              ///< Weight used in the EWMA algorithm.
 
-#define TIME_BASE         (1UL << 22)       ///< Unit used to calculate PPTB (Point per Time Base). It is not equal million to speed up computations and increase precision.
-#define FIRST_RESYNC_TIME TIME_BASE         ///< Delay of the first resynchronization. The first resynchronization is needed to measure timers drift.
-#define RESYNC_TIME       (64 * TIME_BASE)  ///< Delay of following resynchronizations.
-#define EWMA_COEF         (8)               ///< Weight used in the EWMA algorithm.
+#define PPI_CH0                  NRF_PPI_CHANNEL13
+#define PPI_CH1                  NRF_PPI_CHANNEL14
+#define PPI_CHGRP0               NRF_PPI_CHANNEL_GROUP1
 
-#define PPI_CH0    NRF_PPI_CHANNEL13
-#define PPI_CH1    NRF_PPI_CHANNEL14
-#define PPI_CHGRP0 NRF_PPI_CHANNEL_GROUP1
-
-#define PPI_SYNC            PPI_CH0
-#define PPI_TIMESTAMP       PPI_CH1
-#define PPI_TIMESTAMP_GROUP PPI_CHGRP0
+#define PPI_SYNC                 PPI_CH0
+#define PPI_TIMESTAMP            PPI_CH1
+#define PPI_TIMESTAMP_GROUP      PPI_CHGRP0
 
 #if NRF_802154_FRAME_TIMESTAMP_ENABLED
 // Structure holding common timepoint from both timers.
@@ -125,7 +127,8 @@ void nrf_802154_timer_coord_timestamp_prepare(uint32_t event_addr)
     nrf_ppi_channel_and_fork_endpoint_setup(PPI_TIMESTAMP,
                                             event_addr,
                                             nrf_802154_hp_timer_timestamp_task_get(),
-                                            (uint32_t)nrf_ppi_task_group_disable_address_get(PPI_TIMESTAMP_GROUP));
+                                            (uint32_t)nrf_ppi_task_group_disable_address_get(
+                                                PPI_TIMESTAMP_GROUP));
 
     nrf_ppi_group_enable(PPI_TIMESTAMP_GROUP);
 }

--- a/src/nrf_802154_timer_coord.h
+++ b/src/nrf_802154_timer_coord.h
@@ -67,7 +67,7 @@ void nrf_802154_timer_coord_uninit(void);
 
 /**
  * @brief Start the Timer Coordinator.
- * 
+ *
  * This function starts the HP timer and synchronizes it with the LP timer.
  *
  * Started Timer Coordinator resynchronizes automatically in constant interval.

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -47,65 +47,65 @@
  */
 typedef uint8_t nrf_802154_state_t;
 
-#define NRF_802154_STATE_INVALID              0x01 //!< Radio in an invalid state.
-#define NRF_802154_STATE_SLEEP                0x02 //!< Radio in sleep state.
-#define NRF_802154_STATE_RECEIVE              0x03 //!< Radio in receive state.
-#define NRF_802154_STATE_TRANSMIT             0x04 //!< Radio in transmit state.
-#define NRF_802154_STATE_ENERGY_DETECTION     0x05 //!< Radio in energy detection state.
-#define NRF_802154_STATE_CCA                  0x06 //!< Radio in CCA state.
-#define NRF_802154_STATE_CONTINUOUS_CARRIER   0x07 //!< Radio in continuous carrier state.
+#define NRF_802154_STATE_INVALID            0x01 // !< Radio in an invalid state.
+#define NRF_802154_STATE_SLEEP              0x02 // !< Radio in sleep state.
+#define NRF_802154_STATE_RECEIVE            0x03 // !< Radio in receive state.
+#define NRF_802154_STATE_TRANSMIT           0x04 // !< Radio in transmit state.
+#define NRF_802154_STATE_ENERGY_DETECTION   0x05 // !< Radio in energy detection state.
+#define NRF_802154_STATE_CCA                0x06 // !< Radio in CCA state.
+#define NRF_802154_STATE_CONTINUOUS_CARRIER 0x07 // !< Radio in continuous carrier state.
 
 /**
  * @brief Errors reported during frame transmission.
  */
 typedef uint8_t nrf_802154_tx_error_t;
 
-#define NRF_802154_TX_ERROR_NONE              0x00 //!< There is no transmit error.
-#define NRF_802154_TX_ERROR_BUSY_CHANNEL      0x01 //!< CCA reported busy channel prior to transmission.
-#define NRF_802154_TX_ERROR_INVALID_ACK       0x02 //!< Received ACK frame is other than expected.
-#define NRF_802154_TX_ERROR_NO_MEM            0x03 //!< No receive buffer is available to receive an ACK.
-#define NRF_802154_TX_ERROR_TIMESLOT_ENDED    0x04 //!< Radio timeslot ended during transmission procedure.
-#define NRF_802154_TX_ERROR_NO_ACK            0x05 //!< ACK frame was not received during timeout period.
-#define NRF_802154_TX_ERROR_ABORTED           0x06 //!< Procedure was aborted by another driver operation with FORCE priority.
-#define NRF_802154_TX_ERROR_TIMESLOT_DENIED   0x07 //!< Transmission did not start due to denied timeslot request.
+#define NRF_802154_TX_ERROR_NONE            0x00 // !< There is no transmit error.
+#define NRF_802154_TX_ERROR_BUSY_CHANNEL    0x01 // !< CCA reported busy channel prior to transmission.
+#define NRF_802154_TX_ERROR_INVALID_ACK     0x02 // !< Received ACK frame is other than expected.
+#define NRF_802154_TX_ERROR_NO_MEM          0x03 // !< No receive buffer is available to receive an ACK.
+#define NRF_802154_TX_ERROR_TIMESLOT_ENDED  0x04 // !< Radio timeslot ended during transmission procedure.
+#define NRF_802154_TX_ERROR_NO_ACK          0x05 // !< ACK frame was not received during timeout period.
+#define NRF_802154_TX_ERROR_ABORTED         0x06 // !< Procedure was aborted by another driver operation with FORCE priority.
+#define NRF_802154_TX_ERROR_TIMESLOT_DENIED 0x07 // !< Transmission did not start due to denied timeslot request.
 
 /**
  * @brief Possible errors during frame reception.
  */
 typedef uint8_t nrf_802154_rx_error_t;
 
-#define NRF_802154_RX_ERROR_NONE              0x00 //!< There is no receive error.
-#define NRF_802154_RX_ERROR_INVALID_FRAME     0x01 //!< Received a malformed frame.
-#define NRF_802154_RX_ERROR_INVALID_FCS       0x02 //!< Received a frame with invalid checksum.
-#define NRF_802154_RX_ERROR_INVALID_DEST_ADDR 0x03 //!< Received a frame with mismatched destination address.
-#define NRF_802154_RX_ERROR_RUNTIME           0x04 //!< A runtime error occurred (for example, CPU was held for too long).
-#define NRF_802154_RX_ERROR_TIMESLOT_ENDED    0x05 //!< Radio timeslot ended during frame reception.
-#define NRF_802154_RX_ERROR_ABORTED           0x06 //!< Procedure was aborted by another driver operation with FORCE priority.
-#define NRF_802154_RX_ERROR_TIMESLOT_DENIED   0x07 //!< Delayed reception request was rejected due to denied timeslot request.
-#define NRF_802154_RX_ERROR_TIMEOUT           0x08 //!< Frame not received during delayed reception time slot.
+#define NRF_802154_RX_ERROR_NONE              0x00 // !< There is no receive error.
+#define NRF_802154_RX_ERROR_INVALID_FRAME     0x01 // !< Received a malformed frame.
+#define NRF_802154_RX_ERROR_INVALID_FCS       0x02 // !< Received a frame with invalid checksum.
+#define NRF_802154_RX_ERROR_INVALID_DEST_ADDR 0x03 // !< Received a frame with mismatched destination address.
+#define NRF_802154_RX_ERROR_RUNTIME           0x04 // !< A runtime error occurred (for example, CPU was held for too long).
+#define NRF_802154_RX_ERROR_TIMESLOT_ENDED    0x05 // !< Radio timeslot ended during frame reception.
+#define NRF_802154_RX_ERROR_ABORTED           0x06 // !< Procedure was aborted by another driver operation with FORCE priority.
+#define NRF_802154_RX_ERROR_TIMESLOT_DENIED   0x07 // !< Delayed reception request was rejected due to denied timeslot request.
+#define NRF_802154_RX_ERROR_TIMEOUT           0x08 // !< Frame not received during delayed reception time slot.
 
 /**
  * @brief Possible errors during energy detection.
  */
 typedef uint8_t nrf_802154_ed_error_t;
 
-#define NRF_802154_ED_ERROR_ABORTED           0x01 //!< Procedure was aborted by another driver operation with FORCE priority.
+#define NRF_802154_ED_ERROR_ABORTED 0x01 // !< Procedure was aborted by another driver operation with FORCE priority.
 
 /**
  * @brief Possible errors during CCA procedure.
  */
 typedef uint8_t nrf_802154_cca_error_t;
 
-#define NRF_802154_CCA_ERROR_ABORTED          0x01 //!< Procedure was aborted by another driver operation with FORCE priority.
+#define NRF_802154_CCA_ERROR_ABORTED 0x01 // !< Procedure was aborted by another driver operation with FORCE priority.
 
 /**
  * @brief Possible errors during sleep procedure call.
  */
 typedef uint8_t nrf_802154_sleep_error_t;
 
-#define NRF_802154_SLEEP_ERROR_NONE           0x00 //!< There is no error.
-#define NRF_802154_SLEEP_ERROR_BUSY           0x01 //!< The driver cannot enter sleep state due to ongoing operation.
- 
+#define NRF_802154_SLEEP_ERROR_NONE 0x00 // !< There is no error.
+#define NRF_802154_SLEEP_ERROR_BUSY 0x01 // !< The driver cannot enter sleep state due to ongoing operation.
+
 /**
  * @brief Termination level selected for a particular request.
  *
@@ -114,18 +114,18 @@ typedef uint8_t nrf_802154_sleep_error_t;
  */
 typedef uint8_t nrf_802154_term_t;
 
-#define NRF_802154_TERM_NONE    0x00  //!< Request is skipped if another operation is ongoing.
-#define NRF_802154_TERM_802154  0x01  //!< Request terminates ongoing 802.15.4 operation.
+#define NRF_802154_TERM_NONE   0x00 // !< Request is skipped if another operation is ongoing.
+#define NRF_802154_TERM_802154 0x01 // !< Request terminates ongoing 802.15.4 operation.
 
 /**
  * @brief Structure for configuring CCA.
  */
 typedef struct
 {
-    nrf_radio_cca_mode_t mode;           //!< CCA mode.
-    uint8_t              ed_threshold;   //!< CCA energy busy threshold. Not used in NRF_RADIO_CCA_MODE_CARRIER.
-    uint8_t              corr_threshold; //!< CCA correlator busy threshold. Not used in NRF_RADIO_CCA_MODE_ED.
-    uint8_t              corr_limit;     //!< Limit of occurrences above CCA correlator busy threshold. Not used in NRF_RADIO_CCA_MODE_ED.
+    nrf_radio_cca_mode_t mode;           // !< CCA mode.
+    uint8_t              ed_threshold;   // !< CCA energy busy threshold. Not used in NRF_RADIO_CCA_MODE_CARRIER.
+    uint8_t              corr_threshold; // !< CCA correlator busy threshold. Not used in NRF_RADIO_CCA_MODE_ED.
+    uint8_t              corr_limit;     // !< Limit of occurrences above CCA correlator busy threshold. Not used in NRF_RADIO_CCA_MODE_ED.
 } nrf_802154_cca_cfg_t;
 
 /**

--- a/src/nrf_802154_utils.h
+++ b/src/nrf_802154_utils.h
@@ -43,26 +43,25 @@
  */
 
 /**@brief RTC clock frequency. */
-#define NRF_802154_RTC_FREQUENCY                32768UL
+#define NRF_802154_RTC_FREQUENCY               32768UL
 
 /**@brief Defines number of microseconds in one second. */
-#define NRF_802154_US_PER_S                     1000000ULL
+#define NRF_802154_US_PER_S                    1000000ULL
 
 /**@brief Number of microseconds in one RTC tick. (rounded up) */
-#define NRF_802154_US_PER_TICK                  NRF_802154_RTC_TICKS_TO_US(1)
+#define NRF_802154_US_PER_TICK                 NRF_802154_RTC_TICKS_TO_US(1)
 
 /**@brief Number of bits to shift RTC_FREQUENCY and US_PER_S to achieve division by greatest common divisor. */
-#define NRF_802154_FREQUENCY_US_PER_S_GCD_BITS  6
-
+#define NRF_802154_FREQUENCY_US_PER_S_GCD_BITS 6
 
 /**@brief Ceil division helper */
-#define NRF_802154_DIVIDE_AND_CEIL(A, B) (((A) + (B) - 1) / (B))
+#define NRF_802154_DIVIDE_AND_CEIL(A, B)       (((A) + (B)-1) / (B))
 
 /**@brief RTC ticks to us conversion. */
-#define NRF_802154_RTC_TICKS_TO_US(ticks)                                                          \
-    NRF_802154_DIVIDE_AND_CEIL(                                                                    \
-            (ticks) * (NRF_802154_US_PER_S >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS),             \
-            (NRF_802154_RTC_FREQUENCY >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS))
+#define NRF_802154_RTC_TICKS_TO_US(ticks)                                          \
+    NRF_802154_DIVIDE_AND_CEIL(                                                    \
+        (ticks) * (NRF_802154_US_PER_S >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS), \
+        (NRF_802154_RTC_FREQUENCY >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS))
 
 static inline uint64_t NRF_802154_US_TO_RTC_TICKS(uint64_t time)
 {
@@ -101,11 +100,11 @@ static inline uint64_t NRF_802154_US_TO_RTC_TICKS(uint64_t time)
 
        There is a possible loss of precision so that t1 will be up to 93*15625 _smaller_
        than the accurate number. This is taken into account in the next step.
-    */
+     */
 
-    t1 = ((time >> 13) * 0x8637bd0) >> 28; // ((time >> 13) * (2^41 / 15625)) >> (41 - 13)
+    t1     = ((time >> 13) * 0x8637bd0) >> 28; // ((time >> 13) * (2^41 / 15625)) >> (41 - 13)
     result = t1 * 512;
-    t1 = time - t1 * 15625;
+    t1     = time - t1 * 15625;
 
     /* This second step of the calculation is to find out how many RTC units there are
        still left in the remaining microseconds.
@@ -130,9 +129,9 @@ static inline uint64_t NRF_802154_US_TO_RTC_TICKS(uint64_t time)
 
     // ceil((time * (2^56 / 15625)) >> (56 - 9))
     assert(t1 <= 1453125);
-    u1 = (t1 * 0x431bde82d7b); // (time * (2^56 / 15625))
-    u1 += 0x7fffffffffff;      // round up
-    u1 >>= 47;                 // ceil(u1 >> (56 - 9))
+    u1   = (t1 * 0x431bde82d7b); // (time * (2^56 / 15625))
+    u1  += 0x7fffffffffff;       // round up
+    u1 >>= 47;                   // ceil(u1 >> (56 - 9))
 
     result += u1;
 
@@ -149,7 +148,8 @@ static inline uint64_t NRF_802154_US_TO_RTC_TICKS(uint64_t time)
  */
 static inline uint32_t nrf_is_nvic_irq_enabled(IRQn_Type IRQn)
 {
-    return (NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)]) & ((uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL)));
+    return (NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)]) &
+           ((uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL)));
 }
 
 /**

--- a/src/platform/hp_timer/nrf_802154_hp_timer.c
+++ b/src/platform/hp_timer/nrf_802154_hp_timer.c
@@ -49,20 +49,20 @@
 #include "nrf_802154_config.h"
 
 /**@brief Timer instance. */
-#define TIMER                       NRF_TIMER0
+#define TIMER                 NRF_TIMER0
 
 /**@brief Timer compare channel definitions. */
-#define TIMER_CC_CAPTURE            NRF_TIMER_CC_CHANNEL1
-#define TIMER_CC_CAPTURE_TASK       NRF_TIMER_TASK_CAPTURE1
+#define TIMER_CC_CAPTURE      NRF_TIMER_CC_CHANNEL1
+#define TIMER_CC_CAPTURE_TASK NRF_TIMER_TASK_CAPTURE1
 
-#define TIMER_CC_SYNC               NRF_TIMER_CC_CHANNEL2
-#define TIMER_CC_SYNC_TASK          NRF_TIMER_TASK_CAPTURE2
-#define TIMER_CC_SYNC_EVENT         NRF_TIMER_EVENT_COMPARE2
-#define TIMER_CC_SYNC_INT           NRF_TIMER_INT_COMPARE2_MASK
+#define TIMER_CC_SYNC         NRF_TIMER_CC_CHANNEL2
+#define TIMER_CC_SYNC_TASK    NRF_TIMER_TASK_CAPTURE2
+#define TIMER_CC_SYNC_EVENT   NRF_TIMER_EVENT_COMPARE2
+#define TIMER_CC_SYNC_INT     NRF_TIMER_INT_COMPARE2_MASK
 
-#define TIMER_CC_EVT                NRF_TIMER_CC_CHANNEL3
-#define TIMER_CC_EVT_TASK           NRF_TIMER_TASK_CAPTURE3
-#define TIMER_CC_EVT_INT            NRF_TIMER_INT_COMPARE3_MASK
+#define TIMER_CC_EVT          NRF_TIMER_CC_CHANNEL3
+#define TIMER_CC_EVT_TASK     NRF_TIMER_TASK_CAPTURE3
+#define TIMER_CC_EVT_INT      NRF_TIMER_INT_COMPARE3_MASK
 
 /**@brief Unexpected value in the sync compare channel. */
 static uint32_t m_unexpected_sync;
@@ -139,4 +139,3 @@ uint32_t nrf_802154_hp_timer_timestamp_get(void)
 {
     return nrf_timer_cc_read(TIMER, TIMER_CC_EVT);
 }
-

--- a/src/platform/hp_timer/nrf_802154_hp_timer.h
+++ b/src/platform/hp_timer/nrf_802154_hp_timer.h
@@ -134,7 +134,6 @@ uint32_t nrf_802154_hp_timer_timestamp_task_get(void);
  */
 uint32_t nrf_802154_hp_timer_timestamp_get(void);
 
-
 /**
  *@}
  **/

--- a/src/platform/lp_timer/nrf_802154_lp_timer.h
+++ b/src/platform/lp_timer/nrf_802154_lp_timer.h
@@ -146,22 +146,22 @@ bool nrf_802154_lp_timer_is_running(void);
 
 /**
  * @brief Start one-shot synchronization timer that expires at nearest possible timepoint.
- * 
+ *
  * On timer expiration @ref nrf_802154_lp_timer_synchronized function will be called and
  * event returned by @ref nrf_802154_lp_timer_sync_event_get will be triggered.
- * 
+ *
  * @note @ref nrf_802154_lp_timer_synchronized may be called multiple times.
  */
 void nrf_802154_lp_timer_sync_start_now(void);
 
 /**
  * @brief Start one-shot synchronization timer that expires at specified time.
- * 
+ *
  * Start one-shot synchronization timer that will expire @p dt microseconds after @p t0 time.
- * 
+ *
  * On timer expiration @ref nrf_802154_lp_timer_synchronized function will be called and
  * event returned by @ref nrf_802154_lp_timer_sync_event_get will be triggered.
- * 
+ *
  * @param[in]  t0  Number of microseconds representing timer start time.
  * @param[in]  dt  Time of timer expiration as time elapsed from @p t0 [us].
  */
@@ -174,7 +174,7 @@ void nrf_802154_lp_timer_sync_stop(void);
 
 /**
  * @brief Get event used to synchronize this timer with HP Timer
- * 
+ *
  * @return  Address of the peripheral register corresponding to the event that
  *          should be used for timers synchronization.
  */

--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -57,12 +57,11 @@
 #define RTC_SYNC_COMPARE_EVENT          NRF_RTC_EVENT_COMPARE_1
 #define RTC_SYNC_COMPARE_EVENT_MASK     RTC_EVTEN_COMPARE1_Msk
 
-#define US_PER_OVERFLOW                 (512UL * NRF_802154_US_PER_S)  ///< Time that has passed between overflow events. On full RTC speed, it occurs every 512 s.
-#define MIN_RTC_COMPARE_EVENT_DT        (2 * NRF_802154_US_PER_TICK)   ///< Minimum time delta from now before RTC compare event is guaranteed to fire.
+#define US_PER_OVERFLOW                 (512UL * NRF_802154_US_PER_S) ///< Time that has passed between overflow events. On full RTC speed, it occurs every 512 s.
+#define MIN_RTC_COMPARE_EVENT_DT        (2 * NRF_802154_US_PER_TICK)  ///< Minimum time delta from now before RTC compare event is guaranteed to fire.
 
 #define EPOCH_32BIT_US                  (1ULL << 32)
 #define EPOCH_FROM_TIME(time)           ((time) & ((uint64_t)UINT32_MAX << 32))
-
 
 // Struct holding information about compare channel.
 typedef struct
@@ -86,8 +85,7 @@ static const compare_channel_descriptor_t m_cmp_ch[CHANNEL_CNT] = {{RTC_LP_TIMER
                                                                     RTC_SYNC_COMPARE_EVENT,
                                                                     RTC_SYNC_COMPARE_EVENT_MASK}};
 
-static uint64_t m_target_times[CHANNEL_CNT]; ///< Target time of given channel [us].
-
+static uint64_t m_target_times[CHANNEL_CNT];     ///< Target time of given channel [us].
 
 static volatile uint32_t m_offset_counter;       ///< Counter of RTC overflows, incremented by 2 on each OVERFLOW event.
 static volatile uint8_t  m_mutex;                ///< Mutex for write access to @ref m_offset_counter.
@@ -276,7 +274,8 @@ static uint32_t overflow_counter_get(void)
     else
     {
         // Failed to acquire mutex.
-        if (nrf_rtc_event_pending(NRF_802154_RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW) || (m_offset_counter & 0x01))
+        if (nrf_rtc_event_pending(NRF_802154_RTC_INSTANCE,
+                                  NRF_RTC_EVENT_OVERFLOW) || (m_offset_counter & 0x01))
         {
             // Lower priority context is currently incrementing m_offset_counter variable.
             offset = (m_offset_counter + 2) / 2;
@@ -340,6 +339,7 @@ static uint64_t round_up_to_timer_ticks_multiply(uint64_t time)
 {
     uint64_t ticks  = time_to_ticks(time);
     uint64_t result = ticks_to_time(ticks);
+
     return result;
 }
 
@@ -396,7 +396,9 @@ void nrf_802154_lp_timer_init(void)
     // Setup low frequency clock.
     nrf_802154_clock_lfclk_start();
 
-    while (!m_clock_ready) { }
+    while (!m_clock_ready)
+    {
+    }
 
     // Setup RTC timer.
     NVIC_SetPriority(NRF_802154_RTC_IRQN, NRF_802154_RTC_IRQ_PRIORITY);
@@ -517,7 +519,8 @@ void nrf_802154_lp_timer_sync_start_now(void)
         offset_and_counter_get(&offset, &counter);
         now = time_get(offset, counter);
         timer_sync_start_at((uint32_t)now, MIN_RTC_COMPARE_EVENT_DT, &now);
-    } while (counter_get() != counter);
+    }
+    while (counter_get() != counter);
 }
 
 void nrf_802154_lp_timer_sync_start_at(uint32_t t0, uint32_t dt)
@@ -536,7 +539,8 @@ void nrf_802154_lp_timer_sync_stop(void)
 
 uint32_t nrf_802154_lp_timer_sync_event_get(void)
 {
-    return (uint32_t)nrf_rtc_event_address_get(NRF_802154_RTC_INSTANCE, m_cmp_ch[SYNC_CHANNEL].event);
+    return (uint32_t)nrf_rtc_event_address_get(NRF_802154_RTC_INSTANCE,
+                                               m_cmp_ch[SYNC_CHANNEL].event);
 }
 
 uint32_t nrf_802154_lp_timer_sync_time_get(void)

--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -398,6 +398,7 @@ void nrf_802154_lp_timer_init(void)
 
     while (!m_clock_ready)
     {
+        // Intentionally empty
     }
 
     // Setup RTC timer.

--- a/src/platform/temperature/nrf_802154_temperature_none.c
+++ b/src/platform/temperature/nrf_802154_temperature_none.c
@@ -57,4 +57,3 @@ int8_t nrf_802154_temperature_get(void)
 {
     return DEFAULT_TEMPERATURE;
 }
-

--- a/src/rsch/nrf_802154_rsch.h
+++ b/src/rsch/nrf_802154_rsch.h
@@ -72,11 +72,11 @@ typedef enum
  */
 typedef enum
 {
-    RSCH_PRIO_IDLE,                ///< Priority used in the sleep state. With this priority RSCH releases all preconditions.
-    RSCH_PRIO_IDLE_LISTENING,      ///< Priority used during the idle listening procedure.
-    RSCH_PRIO_RX,                  ///< Priority used when a frame is being received.
-    RSCH_PRIO_DETECT,              ///< Priority used to detect channel conditions (CCA, ED).
-    RSCH_PRIO_TX,                  ///< Priority used to transmit a frame.
+    RSCH_PRIO_IDLE,                                    ///< Priority used in the sleep state. With this priority RSCH releases all preconditions.
+    RSCH_PRIO_IDLE_LISTENING,                          ///< Priority used during the idle listening procedure.
+    RSCH_PRIO_RX,                                      ///< Priority used when a frame is being received.
+    RSCH_PRIO_DETECT,                                  ///< Priority used to detect channel conditions (CCA, ED).
+    RSCH_PRIO_TX,                                      ///< Priority used to transmit a frame.
 
     RSCH_PRIO_MIN_APPROVED = RSCH_PRIO_IDLE_LISTENING, ///< Minimal priority indicating that given precondition is approved.
     RSCH_PRIO_MAX          = RSCH_PRIO_TX,             ///< Maximal priority available in the RSCH module.
@@ -87,10 +87,10 @@ typedef enum
  */
 typedef enum
 {
-    RSCH_DLY_TX,      ///< Timeslot for delayed tx operation.
-    RSCH_DLY_RX,      ///< Timeslot for delayed rx operation.
+    RSCH_DLY_TX,     ///< Timeslot for delayed tx operation.
+    RSCH_DLY_RX,     ///< Timeslot for delayed rx operation.
 
-    RSCH_DLY_TS_NUM,  ///< Number of delayed timeslots.
+    RSCH_DLY_TS_NUM, ///< Number of delayed timeslots.
 } rsch_dly_ts_id_t;
 
 /**
@@ -172,7 +172,7 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
  *
  * @param[in]  prec    RSCH precondition to be checked.
  * @param[in]  prio    Minimal required priority level of given precondition.
- * 
+ *
  * @retval true   Precondition @p prec is currently granted.
  * @retval false  Precondition @p prec is not currently granted.
  */

--- a/src/rsch/nrf_802154_rsch_crit_sect.c
+++ b/src/rsch/nrf_802154_rsch_crit_sect.c
@@ -47,7 +47,7 @@
 
 #define RSCH_EVT_NONE (rsch_prio_t)UINT8_MAX
 
-static volatile uint8_t m_rsch_pending_evt;  ///< Indicator of pending RSCH event.
+static volatile uint8_t m_rsch_pending_evt; ///< Indicator of pending RSCH event.
 
 /***************************************************************************************************
  * @section RSCH pending events management
@@ -61,7 +61,8 @@ static void rsch_pending_evt_set(rsch_prio_t prio)
     {
         rsch_pending_evt = __LDREXB(&m_rsch_pending_evt);
         (void)rsch_pending_evt;
-    } while (__STREXB((uint8_t)prio, &m_rsch_pending_evt));
+    }
+    while (__STREXB((uint8_t)prio, &m_rsch_pending_evt));
 }
 
 static rsch_prio_t rsch_pending_evt_clear(void)
@@ -71,7 +72,8 @@ static rsch_prio_t rsch_pending_evt_clear(void)
     do
     {
         evt_value = __LDREXB(&m_rsch_pending_evt);
-    } while (__STREXB(RSCH_EVT_NONE, &m_rsch_pending_evt));
+    }
+    while (__STREXB(RSCH_EVT_NONE, &m_rsch_pending_evt));
 
     return (rsch_prio_t)evt_value;
 }

--- a/src/rsch/raal/nrf_raal_config.h
+++ b/src/rsch/raal/nrf_raal_config.h
@@ -56,7 +56,7 @@ extern "C" {
  *
  */
 #ifndef NRF_RAAL_MAX_CLEAN_UP_TIME_US
-#define NRF_RAAL_MAX_CLEAN_UP_TIME_US  91
+#define NRF_RAAL_MAX_CLEAN_UP_TIME_US 91
 #endif
 
 /**

--- a/src/rsch/raal/simulator/nrf_raal_simulator.c
+++ b/src/rsch/raal/simulator/nrf_raal_simulator.c
@@ -95,11 +95,11 @@ void nrf_raal_init(void)
     NVIC_ClearPendingIRQ(MWU_IRQn);
     NVIC_EnableIRQ(MWU_IRQn);
 
-    NRF_TIMER0->MODE       = TIMER_MODE_MODE_Timer;
-    NRF_TIMER0->BITMODE    = TIMER_BITMODE_BITMODE_24Bit;
-    NRF_TIMER0->PRESCALER  = 4;
-    NRF_TIMER0->INTENSET   = TIMER_INTENSET_COMPARE0_Msk;
-    NRF_TIMER0->CC[0]      = m_started_timestamp;
+    NRF_TIMER0->MODE      = TIMER_MODE_MODE_Timer;
+    NRF_TIMER0->BITMODE   = TIMER_BITMODE_BITMODE_24Bit;
+    NRF_TIMER0->PRESCALER = 4;
+    NRF_TIMER0->INTENSET  = TIMER_INTENSET_COMPARE0_Msk;
+    NRF_TIMER0->CC[0]     = m_started_timestamp;
 
     NVIC_SetPriority(TIMER0_IRQn, 1);
     NVIC_ClearPendingIRQ(TIMER0_IRQn);

--- a/src/rsch/raal/single_phy/single_phy.c
+++ b/src/rsch/raal/single_phy/single_phy.c
@@ -71,7 +71,7 @@ void nrf_raal_continuous_mode_exit(void)
 
 bool nrf_raal_timeslot_request(uint32_t length_us)
 {
-    (void) length_us;
+    (void)length_us;
 
     assert(m_continuous);
 
@@ -82,4 +82,3 @@ uint32_t nrf_raal_timeslot_us_left_get(void)
 {
     return UINT32_MAX;
 }
-

--- a/src/rsch/raal/softdevice/nrf_raal_softdevice.c
+++ b/src/rsch/raal/softdevice/nrf_raal_softdevice.c
@@ -231,6 +231,7 @@ static void timer_on_extend_update(void)
     if (timer_is_set_to_margin())
     {
         uint32_t margin_cc = nrf_timer_cc_read(RAAL_TIMER, TIMER_CC_ACTION);
+
         margin_cc += m_timeslot_length;
         nrf_timer_cc_write(RAAL_TIMER, TIMER_CC_ACTION, margin_cc);
     }
@@ -624,6 +625,7 @@ void nrf_raal_init(void)
     m_config.timeslot_timeout     = NRF_RAAL_TIMESLOT_DEFAULT_TIMEOUT;
 
     uint32_t err_code = sd_radio_session_open(signal_handler);
+
     assert(err_code == NRF_SUCCESS);
     (void)err_code;
 
@@ -635,6 +637,7 @@ void nrf_raal_uninit(void)
     assert(m_initialized);
 
     uint32_t err_code = sd_radio_session_close();
+
     assert(err_code == NRF_SUCCESS);
     (void)err_code;
 

--- a/src/rsch/raal/softdevice/nrf_raal_softdevice.h
+++ b/src/rsch/raal/softdevice/nrf_raal_softdevice.h
@@ -46,30 +46,35 @@ extern "C" {
 #endif
 
 /** @brief RAAL Softdevice default parameters. */
-#define NRF_RAAL_TIMESLOT_DEFAULT_LENGTH      6400
-#define NRF_RAAL_TIMESLOT_DEFAULT_ALLOC_ITERS 5
-#define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN nrf_raal_softdevice_safe_margin_calc(NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM)
-#define NRF_RAAL_TIMESLOT_DEFAULT_TIMEOUT     6400
-#define NRF_RAAL_TIMESLOT_DEFAULT_MAX_LENGTH  120000000
-#define NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM  500
+#define NRF_RAAL_TIMESLOT_DEFAULT_LENGTH                    6400
+#define NRF_RAAL_TIMESLOT_DEFAULT_ALLOC_ITERS               5
+#define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN               nrf_raal_softdevice_safe_margin_calc( \
+        NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM)
+#define NRF_RAAL_TIMESLOT_DEFAULT_TIMEOUT                   6400
+#define NRF_RAAL_TIMESLOT_DEFAULT_MAX_LENGTH                120000000
+#define NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM                500
 
 #define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_LFRC_TICKS    4
 #define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_CRYSTAL_TICKS 3
 #define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_US            3
 
-#define NRF_RAAL_PPM_THRESHOLD 500
+#define NRF_RAAL_PPM_THRESHOLD                              500
 
-#define NRF_RAAL_TIMESLOT_SAFE_MARGIN_TICKS(ppm) ((ppm >= NRF_RAAL_PPM_THRESHOLD) ? \
-                                                  NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_LFRC_TICKS : \
-                                                  NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_CRYSTAL_TICKS)
+#define NRF_RAAL_TIMESLOT_SAFE_MARGIN_TICKS(ppm)            ((ppm >= NRF_RAAL_PPM_THRESHOLD) ?                \
+                                                             NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_LFRC_TICKS \
+                                                             :                                                \
+                                                             NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_CRYSTAL_TICKS)
 
 /**
  * @brief Function used to calculate safe margin from LF clock accuracy in ppm unit.
  *
  * @param[in]  ppm  LF clock accuracy in ppm unit.
  */
-#define nrf_raal_softdevice_safe_margin_calc(ppm) (NRF_802154_RTC_TICKS_TO_US(NRF_RAAL_TIMESLOT_SAFE_MARGIN_TICKS(ppm)) \
-                                                   + NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_US)
+#define nrf_raal_softdevice_safe_margin_calc(ppm)           (NRF_802154_RTC_TICKS_TO_US(              \
+                                                                 NRF_RAAL_TIMESLOT_SAFE_MARGIN_TICKS( \
+                                                                     ppm))                            \
+                                                             +                                        \
+                                                             NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN_US)
 
 /** @brief RAAL Softdevice configuration parameters. */
 typedef struct
@@ -99,7 +104,7 @@ typedef struct
      * @ref nrf_raal_softdevice_safe_margin_calc can be used to calculate proper value based on clock accuracy.
      * This value can also be selected experimentally.
      */
-    uint16_t timeslot_safe_margin; 
+    uint16_t timeslot_safe_margin;
 
     /**
      * @brief @deprecated Clock accuracy in ppm unit.

--- a/src/timer_scheduler/nrf_802154_timer_sched.c
+++ b/src/timer_scheduler/nrf_802154_timer_sched.c
@@ -51,7 +51,7 @@
 #include "platform/lp_timer/nrf_802154_lp_timer.h"
 
 #if defined(__ICCARM__)
-    _Pragma("diag_suppress=Pe167")
+_Pragma("diag_suppress=Pe167")
 #endif
 
 static volatile uint8_t              m_timer_mutex;        ///< Mutex for starting the timer.
@@ -75,7 +75,8 @@ static inline bool mutex_trylock(volatile uint8_t * p_mutex)
             __CLREX();
             return false;
         }
-    } while (__STREXB(1, p_mutex));
+    }
+    while (__STREXB(1, p_mutex));
 
     __DMB();
 
@@ -97,7 +98,8 @@ static inline void queue_cntr_bump(void)
     do
     {
         cntr = __LDREXB(&m_queue_changed_cntr);
-    } while (__STREXB(cntr + 1, &m_queue_changed_cntr));
+    }
+    while (__STREXB(cntr + 1, &m_queue_changed_cntr));
 
     __DMB();
 }
@@ -165,7 +167,8 @@ static inline void handle_timer(void)
 
             mutex_unlock(&m_timer_mutex);
         }
-    } while (queue_cntr != m_queue_changed_cntr);
+    }
+    while (queue_cntr != m_queue_changed_cntr);
 }
 
 /**
@@ -259,7 +262,8 @@ static bool timer_remove(nrf_802154_timer_t * p_timer)
             // This assignment is used to prevent compiler from removing exclusive load during optimization (IAR).
             temp = __LDREXW((uint32_t *)&p_cur->p_next);
             assert((void *)temp != p_cur);
-        } while (__STREXW(temp, (uint32_t *)&p_cur->p_next));
+        }
+        while (__STREXW(temp, (uint32_t *)&p_cur->p_next));
     }
 
     return (timer_start || timer_stop);
@@ -316,7 +320,7 @@ void nrf_802154_timer_sched_add(nrf_802154_timer_t * p_timer, bool round_up)
     }
 
     nrf_802154_timer_t ** pp_item;
-    nrf_802154_timer_t *  p_next;
+    nrf_802154_timer_t  * p_next;
     uint8_t               queue_cntr;
 
     while (true)
@@ -402,7 +406,8 @@ bool nrf_802154_timer_sched_is_running(nrf_802154_timer_t * p_timer)
                 break;
             }
         }
-    } while (queue_cntr != m_queue_changed_cntr);
+    }
+    while (queue_cntr != m_queue_changed_cntr);
 
     return result;
 }
@@ -413,7 +418,7 @@ void nrf_802154_lp_timer_fired(void)
 
     if (mutex_trylock(&m_fired_mutex))
     {
-        nrf_802154_timer_t * p_timer   = (nrf_802154_timer_t *) mp_head;
+        nrf_802154_timer_t * p_timer = (nrf_802154_timer_t *)mp_head;
 
         if (p_timer != NULL)
         {

--- a/src/timer_scheduler/nrf_802154_timer_sched.h
+++ b/src/timer_scheduler/nrf_802154_timer_sched.h
@@ -76,11 +76,11 @@ typedef struct nrf_802154_timer_s nrf_802154_timer_t;
  */
 struct nrf_802154_timer_s
 {
-    uint32_t                       t0;         ///< Base time of the timer [us]
-    uint32_t                       dt;         ///< Timer expiration delta from @p t0 [us]
-    nrf_802154_timer_callback_t    callback;   ///< Callback function called when timer expires
-    void                         * p_context;  ///< User-defined context passed to callback function
-    nrf_802154_timer_t           * p_next;     ///< A pointer to the next running timer
+    uint32_t                    t0;        ///< Base time of the timer [us]
+    uint32_t                    dt;        ///< Timer expiration delta from @p t0 [us]
+    nrf_802154_timer_callback_t callback;  ///< Callback function called when timer expires
+    void                      * p_context; ///< User-defined context passed to callback function
+    nrf_802154_timer_t        * p_next;    ///< A pointer to the next running timer
 };
 
 /**


### PR DESCRIPTION
This PR adds support for `uncrustify` (source code beautifier) and adds new job to the Travis CI. It also introduces `CONTRIBUTING.md `file.

I found almost all code changes desirable. There are two very small issues that i see:
1. In the file `src/nrf_802154_ack_pending_bit.c` not all local variables are correctly aligned due to two lines definition. Uncrustify can be configured to fix it, although it modifies much more other part of code in certainly unwanted way. The tool has concept of span and thresholds which you may try to experiment with if you want.
2. There is space after expresion; `(type) !variable`. This space is of course removed when there is no "!" character.

I suggest to accept those nits and/or improve this later. Sometimes it's useful to make e.g. alignment while sometimes it has less sense (from developer perspective), however tool can't guess user preference - that is one of the drawback of having code style checker. Again i think it is worth to have one.

You may find example successful build (total time: 1 min 11sec):
https://travis-ci.org/LuDuda/nRF-IEEE-802.15.4-radio-driver/builds/455643915

As well as failed one (with clear description what was wrong):
https://travis-ci.org/LuDuda/nRF-IEEE-802.15.4-radio-driver/builds/455638664

Since Travis supports only old Ubuntu 14.04 (Trusty) or a little bit newer Xenial, there is no fresh uncrustify packages out of the box. That's why the tool is built from the scratch. The version 0.66.1 has been chosen since it is a default version in Ubuntu 18.04.

There are three independent commits which should be merged without squashing.

If this PR is accepted, Travis CI has to be enabled for this project (i can take care of that).