### PR TITLE
Update nrf_802154_core.c - bugfix the channel_set function

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -469,7 +469,7 @@ static void channel_set(uint8_t channel)
 {
     assert(channel >= 11 && channel <= 26);
 
-    nrf_radio_frequency_set(5 + (5 * (channel - 11)));
+    nrf_radio_frequency_set(2405 + 5 * (channel - 11));
 }
 
 /***************************************************************************************************

--- a/test/unit tests/fsm_ed/unity_test.c
+++ b/test/unit tests/fsm_ed/unity_test.c
@@ -385,7 +385,7 @@ void test_edend_handler_ShallResetToRxStateAndNotifySuccessIfEdEnded(void)
     nrf_radio_ed_sample_get_ExpectAndReturn(result);
 
     nrf_802154_pib_channel_get_ExpectAndReturn(channel);
-    nrf_radio_frequency_set_Expect((channel - 10) * 5);
+    nrf_radio_frequency_set_Expect(2400 + (channel - 10) * 5);
     verify_ed_terminate_periph_reset(true);
     verify_complete_receive_begin();
 


### PR DESCRIPTION
Fixed the challe_set function after using the radio.h file from the sdk

#223 