### PR TITLE
Do not hang in timer synchronization init without optimizations.

### DIFF
--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -63,6 +63,8 @@
 #define EPOCH_32BIT_US                  (1ULL << 32)
 #define EPOCH_FROM_TIME(time)           ((time) & ((uint64_t)UINT32_MAX << 32))
 
+#define MAX_LP_TIMER_SYNC_ITERS         4
+
 // Struct holding information about compare channel.
 typedef struct
 {
@@ -516,6 +518,7 @@ void nrf_802154_lp_timer_sync_start_now(void)
     uint32_t counter;
     uint32_t offset;
     uint64_t now;
+    uint32_t iterations = MAX_LP_TIMER_SYNC_ITERS;
 
     do
     {
@@ -523,7 +526,7 @@ void nrf_802154_lp_timer_sync_start_now(void)
         now = time_get(offset, counter);
         timer_sync_start_at((uint32_t)now, MIN_RTC_COMPARE_EVENT_DT, &now);
     }
-    while (counter_get() != counter);
+    while ((counter_get() != counter) && (--iterations > 0));
 }
 
 void nrf_802154_lp_timer_sync_start_at(uint32_t t0, uint32_t dt)


### PR DESCRIPTION
There is an operation that must be performed within 1 RTC cycle to make
sure that synchronization would be performed in time. There was an
infinite loop that iterated until operation was performed within 1 RTC
cycle. The problem was that without compiler optimizations single
iteration takes more than 1 RTC cycle. It caused hanging of
initialization procedure.

This patch provides a counter that limits number of iterations of this
loop. If the limit is reached, the operation is not performed again and
the timers are most probably unsynchronized. It is assumed that having
unsynchronized timers is better than hanging up the driver during debug
sessions.