### PR TITLE
Pr/delayed operation cancelation stress

### DIFF
--- a/nRF-IEEE-802.15.4-radio-driver.packsc
+++ b/nRF-IEEE-802.15.4-radio-driver.packsc
@@ -412,6 +412,14 @@
         ]
     },
 
+    "debug_assert_bkpt": {
+        "_class": "nRF_drv_radio_802_15_4",
+        "_description": "This option enables BKPT instruction when handling assert",
+        "_defines": [
+            "ENABLE_DEBUG_ASSERT_BKPT"
+        ]
+    },
+
     "debug_gpio": {
         "_class": "nRF_drv_radio_802_15_4",
         "_description": "This option connects RADIO events with GPIO output.",

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1740,9 +1740,10 @@ static void cont_prec_denied(void)
         {
             irq_deinit();
             nrf_radio_reset();
-            nrf_fem_control_pin_clear();
-            nrf_802154_timer_coord_stop();
         }
+
+        nrf_fem_control_pin_clear();
+        nrf_802154_timer_coord_stop();
 
         result = current_operation_terminate(NRF_802154_TERM_802154, REQ_ORIG_RSCH, false);
         assert(result);

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -183,7 +183,9 @@ void __assert_func(const char * file, int line, const char * func, const char * 
     (void)func;
     (void)cond;
 
+#if defined(ENABLE_DEBUG_ASSERT_BKPT) && (ENABLE_DEBUG_ASSERT_BKPT != 0)
     __BKPT(0);
+#endif
     __disable_irq();
 
     while (1)
@@ -196,7 +198,9 @@ void __aeabi_assert(const char * expr, const char * file, int line)
     (void)file;
     (void)line;
 
+#if defined(ENABLE_DEBUG_ASSERT_BKPT) && (ENABLE_DEBUG_ASSERT_BKPT != 0)
     __BKPT(0);
+#endif
     __disable_irq();
 
     while (1)

--- a/src/rsch/raal/softdevice/nrf_raal_softdevice.c
+++ b/src/rsch/raal/softdevice/nrf_raal_softdevice.c
@@ -788,6 +788,8 @@ void nrf_raal_continuous_mode_exit(void)
         m_continuous = false;
         __DMB();
 
+        nrf_raal_timeslot_ended();
+
         // Emulate signal interrupt to inform SD about end of continuous mode.
         NVIC_SetPendingIRQ(RADIO_IRQn);
         NVIC_EnableIRQ(RADIO_IRQn);


### PR DESCRIPTION
This PR fixes issues found during stress testing with delayed TX/RX

Main problems fixed:
1) in `__assert_func` and `__aeabi_assert` bkpt instruction called when debugger was not connected and called from HardFault exception caused MCU reset. We were not able to detect the reason of fault due to this reset. This instruction is now disabled by default. It can be enabled by defining ENABLE_DEBUG_ASSERT_BKPT to perform debugging
2) SoftDevice RAAL: Added missing notification `nrf_raal_timeslot_ended` when continous mode was left by the driver itself.