### PR TITLE
Pr/bugfix default value nrf 802154 clock irq priority

### DIFF
--- a/src/nrf_802154_config.h
+++ b/src/nrf_802154_config.h
@@ -305,7 +305,7 @@ extern "C" {
  *
  */
 #ifndef NRF_802154_CLOCK_IRQ_PRIORITY
-#define NRF_802154_CLOCK_IRQ_PRIORITY 10
+#define NRF_802154_CLOCK_IRQ_PRIORITY 7
 #endif
 
 /**

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -54,6 +54,7 @@
 #include "nrf_802154_rx_buffer.h"
 #include "nrf_802154_timer_coord.h"
 #include "nrf_802154_types.h"
+#include "nrf_802154_utils.h"
 #include "nrf_egu.h"
 #include "nrf_ppi.h"
 #include "nrf_radio.h"
@@ -567,6 +568,9 @@ static void nrf_radio_reset(void)
 /** Initialize interrupts for radio peripheral. */
 static void irq_init(void)
 {
+#if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_IRQ_PRIORITY)
+#error NRF_802154_IRQ_PRIORITY value out of allowed range
+#endif
     NVIC_SetPriority(RADIO_IRQn, NRF_802154_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(RADIO_IRQn);
 }

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -588,7 +588,7 @@ static void nrf_radio_reset(void)
 static void irq_init(void)
 {
 #if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_IRQ_PRIORITY)
-#error NRF_802154_IRQ_PRIORITY value out of allowed range
+#error NRF_802154_IRQ_PRIORITY value out of the allowed range.
 #endif
     NVIC_SetPriority(RADIO_IRQn, NRF_802154_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(RADIO_IRQn);

--- a/src/nrf_802154_swi.c
+++ b/src/nrf_802154_swi.c
@@ -44,6 +44,7 @@
 #include "nrf_802154_config.h"
 #include "nrf_802154_core.h"
 #include "nrf_802154_rx_buffer.h"
+#include "nrf_802154_utils.h"
 #include "nrf_egu.h"
 #include "platform/clock/nrf_802154_clock.h"
 
@@ -434,6 +435,9 @@ void nrf_802154_swi_init(void)
 
     nrf_egu_int_enable(SWI_EGU, NTF_INT | HFCLK_STOP_INT | REQ_INT);
 
+#if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_SWI_PRIORITY)
+#error NRF_802154_SWI_PRIORITY value out of allowed range
+#endif
     NVIC_SetPriority(SWI_IRQn, NRF_802154_SWI_PRIORITY);
     NVIC_ClearPendingIRQ(SWI_IRQn);
     NVIC_EnableIRQ(SWI_IRQn);

--- a/src/nrf_802154_swi.c
+++ b/src/nrf_802154_swi.c
@@ -449,7 +449,7 @@ void nrf_802154_swi_init(void)
     nrf_egu_int_enable(SWI_EGU, NTF_INT | HFCLK_STOP_INT | REQ_INT);
 
 #if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_SWI_PRIORITY)
-#error NRF_802154_SWI_PRIORITY value out of allowed range
+#error NRF_802154_SWI_PRIORITY value out of the allowed range.
 #endif
     NVIC_SetPriority(SWI_IRQn, NRF_802154_SWI_PRIORITY);
     NVIC_ClearPendingIRQ(SWI_IRQn);

--- a/src/nrf_802154_utils.h
+++ b/src/nrf_802154_utils.h
@@ -63,6 +63,11 @@
         (ticks) * (NRF_802154_US_PER_S >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS), \
         (NRF_802154_RTC_FREQUENCY >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS))
 
+/**@brief Checks if given IRQ priority is in range implemented by the MCU */
+#define NRF_IS_IRQ_PRIORITY_ALLOWED(priority) \
+    (((priority) >= 0) && ((priority) < (1U << (__NVIC_PRIO_BITS))))
+
+
 /**@brief Macro to get the number of elements in an array.
  *
  * @param[in] X   Array.

--- a/src/nrf_802154_utils.h
+++ b/src/nrf_802154_utils.h
@@ -63,7 +63,7 @@
         (ticks) * (NRF_802154_US_PER_S >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS), \
         (NRF_802154_RTC_FREQUENCY >> NRF_802154_FREQUENCY_US_PER_S_GCD_BITS))
 
-/**@brief Checks if given IRQ priority is in range implemented by the MCU */
+/** Checks if the given IRQ priority is within the range implemented by the MCU. */
 #define NRF_IS_IRQ_PRIORITY_ALLOWED(priority) \
     (((priority) >= 0) && ((priority) < (1U << (__NVIC_PRIO_BITS))))
 

--- a/src/nrf_802154_utils.h
+++ b/src/nrf_802154_utils.h
@@ -67,7 +67,6 @@
 #define NRF_IS_IRQ_PRIORITY_ALLOWED(priority) \
     (((priority) >= 0) && ((priority) < (1U << (__NVIC_PRIO_BITS))))
 
-
 /**@brief Macro to get the number of elements in an array.
  *
  * @param[in] X   Array.

--- a/src/platform/clock/nrf_802154_clock_nodrv.c
+++ b/src/platform/clock/nrf_802154_clock_nodrv.c
@@ -48,7 +48,7 @@ void nrf_802154_clock_init(void)
     nrf_clock_lf_src_set(NRF_802154_CLOCK_LFCLK_SOURCE);
 
 #if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_CLOCK_IRQ_PRIORITY)
-#error NRF_802154_CLOCK_IRQ_PRIORITY value out of allowed range
+#error NRF_802154_CLOCK_IRQ_PRIORITY value out of the allowed range.
 #endif
     NVIC_SetPriority(POWER_CLOCK_IRQn, NRF_802154_CLOCK_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(POWER_CLOCK_IRQn);

--- a/src/platform/clock/nrf_802154_clock_nodrv.c
+++ b/src/platform/clock/nrf_802154_clock_nodrv.c
@@ -41,11 +41,15 @@
 #include <nrf_clock.h>
 
 #include "nrf_802154_config.h"
+#include "nrf_802154_utils.h"
 
 void nrf_802154_clock_init(void)
 {
     nrf_clock_lf_src_set(NRF_802154_CLOCK_LFCLK_SOURCE);
 
+#if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_CLOCK_IRQ_PRIORITY)
+#error NRF_802154_CLOCK_IRQ_PRIORITY value out of allowed range
+#endif
     NVIC_SetPriority(POWER_CLOCK_IRQn, NRF_802154_CLOCK_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(POWER_CLOCK_IRQn);
     NVIC_EnableIRQ(POWER_CLOCK_IRQn);

--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -405,6 +405,9 @@ void nrf_802154_lp_timer_init(void)
     }
 
     // Setup RTC timer.
+#if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_RTC_IRQ_PRIORITY)
+#error NRF_802154_RTC_IRQ_PRIORITY value out of allowed range
+#endif
     NVIC_SetPriority(NRF_802154_RTC_IRQN, NRF_802154_RTC_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(NRF_802154_RTC_IRQN);
     NVIC_EnableIRQ(NRF_802154_RTC_IRQN);

--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -406,7 +406,7 @@ void nrf_802154_lp_timer_init(void)
 
     // Setup RTC timer.
 #if !NRF_IS_IRQ_PRIORITY_ALLOWED(NRF_802154_RTC_IRQ_PRIORITY)
-#error NRF_802154_RTC_IRQ_PRIORITY value out of allowed range
+#error NRF_802154_RTC_IRQ_PRIORITY value out of the allowed range.
 #endif
     NVIC_SetPriority(NRF_802154_RTC_IRQN, NRF_802154_RTC_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(NRF_802154_RTC_IRQN);


### PR DESCRIPTION
Fixed default value for NRF_802154_CLOCK_IRQ_PRIORITY 
Added preprocessor checks if IRQ priorities from nrf_802154_config.h are in valid range for given MCU.