### PR TITLE
Don't wait indefinitely for RSSI measurement

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -246,7 +246,8 @@ static void rssi_measurement_wait(void)
 {
     while (!nrf_radio_event_check(NRF_RADIO_EVENT_RSSIEND))
     {
-        nrf_802154_busy_wait();
+        // Intentionally empty: This function is called from a critical section.
+        // WFE would not be waken up by a RADIO event.
     }
 }
 


### PR DESCRIPTION
Waiting for RSSI measurement end is just waiting for the RSSIEND event.
The event is not configured to trigger an interrupt. Moreover, waiting
for RSSI measurement is performed in a critical section where all RADIO
interrupts are masked. That's why waiting for an event may be indefinite
during this procedure.