### PR TITLE
Introduce support for the 3-pin frontend module

### DIFF
--- a/nRF-IEEE-802.15.4-radio-driver.packsc
+++ b/nRF-IEEE-802.15.4-radio-driver.packsc
@@ -344,6 +344,9 @@
             "src/fem/nrf_fem_protocol_api.h",
             "src/fem/nrf_fem_protocol_legacy_api.h"
         ],
+        "_includes" : [
+            "src/fem"
+        ],
         "_defines": [
             "ENABLE_FEM"
         ],
@@ -352,12 +355,31 @@
                 "_attrs": [
                     "public"
                 ],
+                "_includes": [
+                    "src/fem/simple_gpio"
+                ],
                 "_links": [
                     "nrfx_hal"
                 ],
                 "_files": [
-                    "src/fem/nrf_fem_control.c"
-                ]
+                    "src/fem/simple_gpio/nrf_fem_simple_gpio.c"
+                ],
+                "_name": "simple"
+            },
+            {
+                "_attrs": [
+                    "public"
+                ],
+                "_includes": [
+                    "src/fem/three_pin_gpio"
+                ],
+                "_links": [
+                    "nrfx_hal"
+                ],
+                "_files": [
+                    "src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c"
+                ],
+                "_name": "three_pin_gpio"
             },
             {
                 "_attrs": [

--- a/nRF-IEEE-802.15.4-radio-driver.packsc
+++ b/nRF-IEEE-802.15.4-radio-driver.packsc
@@ -364,7 +364,7 @@
                 "_files": [
                     "src/fem/simple_gpio/nrf_fem_simple_gpio.c"
                 ],
-                "_name": "simple_gpio"
+                "_name": "simple"
             },
             {
                 "_attrs": [

--- a/nRF-IEEE-802.15.4-radio-driver.packsc
+++ b/nRF-IEEE-802.15.4-radio-driver.packsc
@@ -364,7 +364,7 @@
                 "_files": [
                     "src/fem/simple_gpio/nrf_fem_simple_gpio.c"
                 ],
-                "_name": "simple"
+                "_name": "simple_gpio"
             },
             {
                 "_attrs": [
@@ -393,7 +393,8 @@
                 ],
                 "_includes": [
                     "cmock",
-                    "src/fem"
+                    "src/fem",
+                    "src/fem/none"
                 ],
                 "_name": "cmock"
             },

--- a/src/fem/none/nrf_fem_config.h
+++ b/src/fem/none/nrf_fem_config.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF_FEM_CONFIG_H_
+#define NRF_FEM_CONFIG_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration parameters for pins that enable or disable (or both) either Power Amplifier (PA) or Low Noise Amplifier (LNA).
+ */
+typedef struct
+{
+
+} nrf_fem_gpiote_pin_config_t;
+
+/**
+ * @brief Configuration parameters for the PA/LNA interface.
+ */
+typedef struct
+{
+
+} nrf_fem_interface_config_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_FEM_CONFIG_H_ */

--- a/src/fem/nrf_fem_control_config.h
+++ b/src/fem/nrf_fem_control_config.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,87 +31,16 @@
 #ifndef NRF_FEM_CONTROL_CONFIG_H_
 #define NRF_FEM_CONTROL_CONFIG_H_
 
+#if ENABLE_FEM
+#include "nrf_fem_config.h"
+#endif // ENABLE_FEM
+
 #include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief Configuration parameters for pins that enable or disable (or both) either Power Amplifier (PA) or Low Noise Amplifier (LNA).
- */
-typedef struct
-{
-    bool    enable;       /* Enable toggling for this pin. */
-    bool    active_high;  /* If true, the pin will be active high. Otherwise, the pin will be active low. */
-    uint8_t gpio_pin;     /* GPIO pin number for the pin. */
-    uint8_t gpiote_ch_id; /* GPIOTE channel to be used for toggling pins. */
-} nrf_fem_gpiote_pin_config_t;
-
-/**
- * @brief Configuration parameters for the PA/LNA interface.
- */
-typedef struct
-{
-    struct
-    {
-        uint32_t pa_time_gap_us;                /* Time between the activation of the PA pin and the start of the radio transmission. */
-        uint32_t lna_time_gap_us;               /* Time between the activation of the LNA pin and the start of the radio reception. */
-        int8_t   pa_gain_db;                    /* Configurable PA gain. Ignored if the amplifier is not supporting this feature. */
-        int8_t   lna_gain_db;                   /* Configurable LNA gain. Ignored if the amplifier is not supporting this feature. */
-    }                           fem_config;
-
-    nrf_fem_gpiote_pin_config_t pa_pin_config;  /* Power Amplifier pin configuration. */
-    nrf_fem_gpiote_pin_config_t lna_pin_config; /* Low Noise Amplifier pin configuration. */
-
-    int                         ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
-    int                         ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
-} nrf_fem_interface_config_t;
-
-/**
- * @section Timings.
- */
-
-/** Time in microseconds when PA GPIO is activated before the radio is ready for transmission. */
-#define NRF_FEM_PA_TIME_IN_ADVANCE          23
-
-/** Time in microseconds when LNA GPIO is activated before the radio is ready for reception. */
-#define NRF_FEM_LNA_TIME_IN_ADVANCE         5
-
-/** Radio ramp-up time in TX mode, in microseconds. */
-#define NRF_FEM_RADIO_TX_STARTUP_LATENCY_US 40
-
-/** Radio ramp-up time in RX mode, in microseconds. */
-#define NRF_FEM_RADIO_RX_STARTUP_LATENCY_US 40
-
-#ifdef NRF52811_XXAA
-/** Default Power Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  19
-
-/** Default Low Noise Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 20
-
-#else
-
-/** Default Power Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  15
-
-/** Default Low Noise Amplifier pin. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 16
-#endif
-
-/** Default PPI channel for pin setting. */
-#define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15
-
-/** Default PPI channel for pin clearing. */
-#define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL    16
-
-/** Default GPIOTE channel for FEM control. */
-#define NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL 6
-
-/** Default GPIOTE channel for FEM control. */
-#define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
 
 /**
  * @section Configuration
@@ -152,8 +81,9 @@ int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_confi
 
 #else // ENABLE_FEM
 
-static inline int32_t nrf_fem_interface_configuration_set(
-    nrf_fem_interface_config_t const * const p_config)
+typedef void nrf_fem_interface_config_t;
+
+static inline int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * const p_config)
 {
     (void)p_config;
     return NRF_ERROR_NOT_SUPPORTED;

--- a/src/fem/nrf_fem_control_config.h
+++ b/src/fem/nrf_fem_control_config.h
@@ -83,7 +83,8 @@ int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_confi
 
 typedef void nrf_fem_interface_config_t;
 
-static inline int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * const p_config)
+static inline int32_t nrf_fem_interface_configuration_set(
+    nrf_fem_interface_config_t const * const p_config)
 {
     (void)p_config;
     return NRF_ERROR_NOT_SUPPORTED;

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -212,11 +212,11 @@ void nrf_802154_fal_cleanup(void);
 void nrf_802154_fal_pa_is_configured(int8_t * const p_gain);
 
 /**
- * @brief Prepare the FEM module to switch to the Power Down state.
+ * @brief Prepares the FEM module to switch to the Power Down state.
  *
- * @param[in]  p_instance Timer instance which is used to schedule the transition to the Power Down state.
- * @param[in] compare_channel The Compare Channel to hold a value for the timer.
- * @param[in] ppi_id The id of the PPI channel used to switch to the Power Down state.
+ * @param[in] p_instance Timer instance that is used to schedule the transition to the Power Down state.
+ * @param[in] compare_channel Compare channel to hold a value for the timer.
+ * @param[in] ppi_id ID of the PPI channel used to switch to the Power Down state.
  *
  * @return bool Whether the scheduling of the transition was successful or not.
  *

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -138,6 +138,7 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
  * @param[in] p_deactivate_event Pointer to the deactivation event structure.
  *
  * @retval   ::NRF_SUCCESS               PA activate setup purge is successful.
+ * @retval   ::NRF_ERROR_FORBIDDEN       PA is currently disabled.
  * @retval   ::NRF_ERROR_INVALID_STATE   PA activate setup purge could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
@@ -181,12 +182,13 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
  * @param[in] p_deactivate_event Pointer to the deactivation event structure.
  *
  * @retval   ::NRF_SUCCESS               LNA activate setup purge is successful.
+ * @retval   ::NRF_ERROR_FORBIDDEN       LNA is currently disabled.
  * @retval   ::NRF_ERROR_INVALID_STATE   LNA activate setup purge could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
-int32_t nrf_802154_fal_lna_configuration_clear(
-    const nrf_802154_fal_event_t * const p_activate_event,
+int32_t nrf_802154_fal_lna_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
     const nrf_802154_fal_event_t * const p_deactivate_event);
+
 
 /**
  * @brief Deactivates PA/LNA pins with immediate effect.
@@ -208,6 +210,18 @@ void nrf_802154_fal_cleanup(void);
  *
  */
 void nrf_802154_fal_pa_is_configured(int8_t * const p_gain);
+
+/**
+ * @brief Prepare the FEM module to switch to the Power Down state.
+ *
+ * @param[in]  p_instance Timer instance which is used to schedule the transition to the Power Down state.
+ * @param[in] compare_channel The Compare Channel to hold a value for the timer.
+ * @param[in] ppi_id The id of the PPI channel used to switch to the Power Down state.
+ *
+ * @return bool Whether the scheduling of the transition was successful or not.
+ *
+ */
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id);
 
 #else // ENABLE_FEM
 
@@ -256,6 +270,15 @@ static inline void nrf_802154_fal_cleanup(void)
 {
 
 }
+
+static inline bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+{
+    (void)p_instance;
+    (void)compare_channel;
+    (void)ppi_id;
+    return false;
+}
+
 
 static inline void nrf_802154_fal_pa_is_configured(int8_t * const p_gain)
 {

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -186,9 +186,9 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
  * @retval   ::NRF_ERROR_INVALID_STATE   LNA activate setup purge could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
-int32_t nrf_802154_fal_lna_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
+int32_t nrf_802154_fal_lna_configuration_clear(
+    const nrf_802154_fal_event_t * const p_activate_event,
     const nrf_802154_fal_event_t * const p_deactivate_event);
-
 
 /**
  * @brief Deactivates PA/LNA pins with immediate effect.
@@ -221,7 +221,9 @@ void nrf_802154_fal_pa_is_configured(int8_t * const p_gain);
  * @return bool Whether the scheduling of the transition was successful or not.
  *
  */
-bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id);
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type  * p_instance,
+                               uint32_t          compare_channel,
+                               nrf_ppi_channel_t ppi_id);
 
 #else // ENABLE_FEM
 
@@ -271,14 +273,15 @@ static inline void nrf_802154_fal_cleanup(void)
 
 }
 
-static inline bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+static inline bool nrf_fem_prepare_powerdown(NRF_TIMER_Type  * p_instance,
+                                             uint32_t          compare_channel,
+                                             nrf_ppi_channel_t ppi_id)
 {
     (void)p_instance;
     (void)compare_channel;
     (void)ppi_id;
     return false;
 }
-
 
 static inline void nrf_802154_fal_pa_is_configured(int8_t * const p_gain)
 {

--- a/src/fem/nrf_fem_protocol_legacy_api.h
+++ b/src/fem/nrf_fem_protocol_legacy_api.h
@@ -35,7 +35,9 @@
  */
 typedef struct
 {
-    uint8_t enable; /**< Enable toggling for this amplifier. */
+    uint8_t enable      : 1; /**< Enable toggling for this amplifier. */
+    uint8_t active_high : 1; /**< Set the pin to be active high. */
+    uint8_t gpio_pin    : 6; /**< The GPIO pin to be toggled for this amplifier. */
 } nrf_fem_control_pa_lna_cfg_t;
 
 /**
@@ -54,4 +56,8 @@ typedef struct
 {
     nrf_fem_control_pa_lna_cfg_t pa_cfg;           /**< Power Amplifier configuration. */
     nrf_fem_control_pa_lna_cfg_t lna_cfg;          /**< Low Noise Amplifier configuration. */
+    uint8_t                      pa_gpiote_ch_id;  /**< GPIOTE channel used for Power Amplifier pin toggling. */
+    uint8_t                      lna_gpiote_ch_id; /**< GPIOTE channel used for Low Noise Amplifier pin toggling. */
+    uint8_t                      ppi_ch_id_set;    /**< PPI channel used for radio Power Amplifier and Low Noise Amplifier pins setting. */
+    uint8_t                      ppi_ch_id_clr;    /**< PPI channel used for radio pin clearing. */    
 } nrf_fem_control_cfg_t;

--- a/src/fem/nrf_fem_protocol_legacy_api.h
+++ b/src/fem/nrf_fem_protocol_legacy_api.h
@@ -35,9 +35,7 @@
  */
 typedef struct
 {
-    uint8_t enable      : 1; /**< Enable toggling for this amplifier. */
-    uint8_t active_high : 1; /**< Set the pin to be active high. */
-    uint8_t gpio_pin    : 6; /**< The GPIO pin to be toggled for this amplifier. */
+    uint8_t enable; /**< Enable toggling for this amplifier. */
 } nrf_fem_control_pa_lna_cfg_t;
 
 /**
@@ -56,8 +54,4 @@ typedef struct
 {
     nrf_fem_control_pa_lna_cfg_t pa_cfg;           /**< Power Amplifier configuration. */
     nrf_fem_control_pa_lna_cfg_t lna_cfg;          /**< Low Noise Amplifier configuration. */
-    uint8_t                      pa_gpiote_ch_id;  /**< GPIOTE channel used for Power Amplifier pin toggling. */
-    uint8_t                      lna_gpiote_ch_id; /**< GPIOTE channel used for Low Noise Amplifier pin toggling. */
-    uint8_t                      ppi_ch_id_set;    /**< PPI channel used for radio Power Amplifier and Low Noise Amplifier pins setting. */
-    uint8_t                      ppi_ch_id_clr;    /**< PPI channel used for radio pin clearing. */
 } nrf_fem_control_cfg_t;

--- a/src/fem/nrf_fem_protocol_legacy_api.h
+++ b/src/fem/nrf_fem_protocol_legacy_api.h
@@ -59,5 +59,5 @@ typedef struct
     uint8_t                      pa_gpiote_ch_id;  /**< GPIOTE channel used for Power Amplifier pin toggling. */
     uint8_t                      lna_gpiote_ch_id; /**< GPIOTE channel used for Low Noise Amplifier pin toggling. */
     uint8_t                      ppi_ch_id_set;    /**< PPI channel used for radio Power Amplifier and Low Noise Amplifier pins setting. */
-    uint8_t                      ppi_ch_id_clr;    /**< PPI channel used for radio pin clearing. */    
+    uint8_t                      ppi_ch_id_clr;    /**< PPI channel used for radio pin clearing. */
 } nrf_fem_control_cfg_t;

--- a/src/fem/simple_gpio/nrf_fem_config.h
+++ b/src/fem/simple_gpio/nrf_fem_config.h
@@ -65,8 +65,8 @@ typedef struct
     nrf_fem_gpiote_pin_config_t pa_pin_config;  /* Power Amplifier pin configuration. */
     nrf_fem_gpiote_pin_config_t lna_pin_config; /* Low Noise Amplifier pin configuration. */
 
-    int                         ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
-    int                         ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
+    uint8_t                     ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
+    uint8_t                     ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
 } nrf_fem_interface_config_t;
 
 /**
@@ -74,10 +74,10 @@ typedef struct
  */
 
 /** Time in microseconds when PA GPIO is activated before the radio is ready for transmission. */
-#define NRF_FEM_PA_TIME_IN_ADVANCE  23
+#define NRF_FEM_PA_TIME_IN_ADVANCE_US  23
 
 /** Time in microseconds when LNA GPIO is activated before the radio is ready for reception. */
-#define NRF_FEM_LNA_TIME_IN_ADVANCE 5
+#define NRF_FEM_LNA_TIME_IN_ADVANCE_US 5
 
 #ifdef NRF52811_XXAA
 /** Default Power Amplifier pin. */

--- a/src/fem/simple_gpio/nrf_fem_config.h
+++ b/src/fem/simple_gpio/nrf_fem_config.h
@@ -1,0 +1,114 @@
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF_FEM_CONFIG_H_
+#define NRF_FEM_CONFIG_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration parameters for pins that enable or disable (or both) either Power Amplifier (PA) or Low Noise Amplifier (LNA).
+ */
+typedef struct
+{
+    bool    enable;       /* Enable toggling for this pin. */
+    bool    active_high;  /* If true, the pin will be active high. Otherwise, the pin will be active low. */
+    uint8_t gpio_pin;     /* GPIO pin number for the pin. */
+    uint8_t gpiote_ch_id; /* GPIOTE channel to be used for toggling pins. */
+} nrf_fem_gpiote_pin_config_t;
+
+/**
+ * @brief Configuration parameters for the PA/LNA interface.
+ */
+typedef struct
+{
+    struct
+    {
+        uint32_t pa_time_gap_us;                /* Time between the activation of the PA pin and the start of the radio transmission. */
+        uint32_t lna_time_gap_us;               /* Time between the activation of the LNA pin and the start of the radio reception. */
+        int8_t   pa_gain_db;                    /* Configurable PA gain. Ignored if the amplifier is not supporting this feature. */
+        int8_t   lna_gain_db;                   /* Configurable LNA gain. Ignored if the amplifier is not supporting this feature. */
+    }                           fem_config;
+
+    nrf_fem_gpiote_pin_config_t pa_pin_config;  /* Power Amplifier pin configuration. */
+    nrf_fem_gpiote_pin_config_t lna_pin_config; /* Low Noise Amplifier pin configuration. */
+
+    int                         ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
+    int                         ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
+} nrf_fem_interface_config_t;
+
+/**
+ * @section Timings.
+ */
+
+/** Time in microseconds when PA GPIO is activated before the radio is ready for transmission. */
+#define NRF_FEM_PA_TIME_IN_ADVANCE  23
+
+/** Time in microseconds when LNA GPIO is activated before the radio is ready for reception. */
+#define NRF_FEM_LNA_TIME_IN_ADVANCE 5
+
+#ifdef NRF52811_XXAA
+/** Default Power Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  19
+
+/** Default Low Noise Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 20
+
+#else
+
+/** Default Power Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  15
+
+/** Default Low Noise Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 16
+#endif
+
+/** Default PPI channel for pin setting. */
+#define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15
+
+/** Default PPI channel for pin clearing. */
+#define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL    16
+
+/** Default GPIOTE channel for FEM control. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL 6
+
+/** Default GPIOTE channel for FEM control. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_FEM_CONFIG_H_ */

--- a/src/fem/simple_gpio/nrf_fem_simple_gpio.c
+++ b/src/fem/simple_gpio/nrf_fem_simple_gpio.c
@@ -51,33 +51,33 @@
 
 #if ENABLE_FEM
 
-#define PPI_INVALID_CHANNEL 0xFF                                           /**< Default value for the PPI holder variable. */
+#define PPI_INVALID_CHANNEL 0xFF                               /**< Default value for the PPI holder variable. */
 
-static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< FEM controller configuration. */
+static nrf_fem_interface_config_t m_nrf_fem_interface_config = /**< FEM controller configuration. */
 {
     .fem_config =
     {
-        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE_US,
+        .pa_time_gap_us  = NRF_FEM_PA_TIME_IN_ADVANCE_US,
         .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE_US
     },
     .pa_pin_config =
     {
-        .enable = 1,
-        .active_high = 1,
-        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
+        .enable       = 1,
+        .active_high  = 1,
+        .gpio_pin     = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
         .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL
     },
     .lna_pin_config =
     {
-        .enable = 1,
-        .active_high = 1,
-        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
+        .enable       = 1,
+        .active_high  = 1,
+        .gpio_pin     = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
         .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL
     },
     .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,
     .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL
 };
-static uint8_t                    m_ppi_channel_ext = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
+static uint8_t m_ppi_channel_ext = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
 
 /** Map the mask bits with the Compare Channels. */
 static uint32_t get_first_available_compare_channel(uint8_t mask)
@@ -457,7 +457,9 @@ void nrf_802154_fal_cleanup(void)
     }
 }
 
-bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type  * p_instance,
+                               uint32_t          compare_channel,
+                               nrf_ppi_channel_t ppi_id)
 {
     (void)p_instance;
     (void)compare_channel;

--- a/src/fem/simple_gpio/nrf_fem_simple_gpio.c
+++ b/src/fem/simple_gpio/nrf_fem_simple_gpio.c
@@ -53,7 +53,30 @@
 
 #define PPI_INVALID_CHANNEL 0xFF                                           /**< Default value for the PPI holder variable. */
 
-static nrf_fem_interface_config_t m_nrf_fem_interface_config;              /**< FEM controller configuration. */
+static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< FEM controller configuration. */
+{
+    .fem_config =
+    {
+        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE,
+        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE
+    },
+    .pa_pin_config =
+    {
+        .enable = 1,
+        .active_high = 1,
+        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
+        .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL
+    },
+    .lna_pin_config =
+    {
+        .enable = 1,
+        .active_high = 1,
+        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
+        .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL
+    },
+    .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,
+    .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL
+};
 static uint8_t                    m_ppi_channel_ext = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
 
 /** Map the mask bits with the Compare Channels. */
@@ -129,8 +152,8 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
     else
     {
         ppi_ch =
-            activate ? m_nrf_fem_interface_config.ppi_ch_id_set :
-            m_nrf_fem_interface_config.ppi_ch_id_clr;
+            activate ? m_nrf_fem_interface_config.ppi_ch_id_set : m_nrf_fem_interface_config.
+            ppi_ch_id_clr;
     }
 
     if (p_pin_config->active_high ^ activate)
@@ -432,6 +455,11 @@ void nrf_802154_fal_cleanup(void)
         nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)m_ppi_channel_ext, 0);
         m_ppi_channel_ext = PPI_INVALID_CHANNEL;
     }
+}
+
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+{
+    return false;
 }
 
 #endif // ENABLE_FEM

--- a/src/fem/simple_gpio/nrf_fem_simple_gpio.c
+++ b/src/fem/simple_gpio/nrf_fem_simple_gpio.c
@@ -57,8 +57,8 @@ static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< 
 {
     .fem_config =
     {
-        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE,
-        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE
+        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE_US,
+        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE_US
     },
     .pa_pin_config =
     {
@@ -459,6 +459,9 @@ void nrf_802154_fal_cleanup(void)
 
 bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
 {
+    (void)p_instance;
+    (void)compare_channel;
+    (void)ppi_id;
     return false;
 }
 

--- a/src/fem/three_pin_gpio/nrf_fem_config.h
+++ b/src/fem/three_pin_gpio/nrf_fem_config.h
@@ -1,0 +1,133 @@
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF_FEM_CONFIG_H_
+#define NRF_FEM_CONFIG_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration parameters for pins that enable or disable (or both) either Power Amplifier (PA) or Low Noise Amplifier (LNA).
+ */
+typedef struct
+{
+    bool    enable;       /* Enable toggling for this pin. */
+    bool    active_high;  /* If true, the pin will be active high. Otherwise, the pin will be active low. */
+    uint8_t gpio_pin;     /* GPIO pin number for the pin. */
+    uint8_t gpiote_ch_id; /* GPIOTE channel to be used for toggling pins. */
+} nrf_fem_gpiote_pin_config_t;
+
+/**
+ * @brief Configuration parameters for the PA/LNA interface.
+ */
+typedef struct
+{
+    struct
+    {
+        uint32_t pa_time_gap_us;                /* Time between the activation of the PA pin and the start of the radio transmission. */
+        uint32_t lna_time_gap_us;               /* Time between the activation of the LNA pin and the start of the radio reception. */
+        uint32_t pdn_settle_us;                 /* The time between activating the PDN and asserting the PA/LNA pin. */
+        uint32_t trx_hold_us;                   /* The time between deasserting the PA/LNA pin and deactivating PDN. */
+        int8_t   pa_gain_db;                    /* Configurable PA gain. Ignored if the amplifier is not supporting this feature. */
+        int8_t   lna_gain_db;                   /* Configurable LNA gain. Ignored if the amplifier is not supporting this feature. */
+    }                           fem_config;
+
+    nrf_fem_gpiote_pin_config_t pa_pin_config;  /* Power Amplifier pin configuration. */
+    nrf_fem_gpiote_pin_config_t lna_pin_config; /* Low Noise Amplifier pin configuration. */
+    nrf_fem_gpiote_pin_config_t pdn_pin_config; /* Power Down pin configuration. */
+
+    uint8_t                     ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
+    uint8_t                     ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
+    uint8_t                     ppi_ch_id_pdn;  /* PPI channel to handle PDN pin. */
+} nrf_fem_interface_config_t;
+
+/**
+ * @section Timings.
+ */
+
+/** Time in microseconds when PA GPIO is activated before the radio is ready for transmission. */
+#define NRF_FEM_PA_TIME_IN_ADVANCE  13
+
+/** Time in microseconds when LNA GPIO is activated before the radio is ready for reception. */
+#define NRF_FEM_LNA_TIME_IN_ADVANCE 13
+
+/** The time between activating the PDN and asserting the RX_EN/TX_EN. */
+#define NRF_FEM_PDN_SETTLE_TIME_IN_ADVANCE 18
+
+/** The time between deasserting the RX_EN/TX_EN and deactivating PDN. */
+#define NRF_FEM_TRX_HOLD_TIME_IN_ADVANCE 5
+
+#ifdef NRF52811_XXAA
+/** Default Power Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  19
+
+/** Default Low Noise Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 20
+
+#else
+
+/** Default Power Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_PIN  15
+
+/** Default Low Noise Amplifier pin. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_PIN 16
+#endif
+
+/** Default Eagle PDN pin. */
+#define NRF_FEM_CONTROL_DEFAULT_PDN_PIN 24
+
+/** Default PPI channel for pin setting. */
+#define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15
+
+/** Default PPI channel for pin clearing. */
+#define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL    16
+
+/** Default PPI channel for PDN pin handling. */
+#define NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL    17
+
+/** Default GPIOTE channel for PDN control. */
+#define NRF_FEM_CONTROL_DEFAULT_PDN_GPIOTE_CHANNEL 5
+
+/** Default GPIOTE channel for LNA control. */
+#define NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL 6
+
+/** Default GPIOTE channel for PA control. */
+#define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_FEM_CONFIG_H_ */

--- a/src/fem/three_pin_gpio/nrf_fem_config.h
+++ b/src/fem/three_pin_gpio/nrf_fem_config.h
@@ -84,10 +84,10 @@ typedef struct
 #define NRF_FEM_LNA_TIME_IN_ADVANCE_US 13
 
 /** The time between activating the PDN and asserting the RX_EN/TX_EN. */
-#define NRF_FEM_PDN_SETTLE_US 18
+#define NRF_FEM_PDN_SETTLE_US          18
 
 /** The time between deasserting the RX_EN/TX_EN and deactivating PDN. */
-#define NRF_FEM_TRX_HOLD_US 5
+#define NRF_FEM_TRX_HOLD_US            5
 
 #ifdef NRF52811_XXAA
 /** Default Power Amplifier pin. */
@@ -106,7 +106,7 @@ typedef struct
 #endif
 
 /** Default Eagle PDN pin. */
-#define NRF_FEM_CONTROL_DEFAULT_PDN_PIN 24
+#define NRF_FEM_CONTROL_DEFAULT_PDN_PIN            24
 
 /** Default PPI channel for pin setting. */
 #define NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL    15

--- a/src/fem/three_pin_gpio/nrf_fem_config.h
+++ b/src/fem/three_pin_gpio/nrf_fem_config.h
@@ -78,16 +78,16 @@ typedef struct
  */
 
 /** Time in microseconds when PA GPIO is activated before the radio is ready for transmission. */
-#define NRF_FEM_PA_TIME_IN_ADVANCE  13
+#define NRF_FEM_PA_TIME_IN_ADVANCE_US  13
 
 /** Time in microseconds when LNA GPIO is activated before the radio is ready for reception. */
-#define NRF_FEM_LNA_TIME_IN_ADVANCE 13
+#define NRF_FEM_LNA_TIME_IN_ADVANCE_US 13
 
 /** The time between activating the PDN and asserting the RX_EN/TX_EN. */
-#define NRF_FEM_PDN_SETTLE_TIME_IN_ADVANCE 18
+#define NRF_FEM_PDN_SETTLE_US 18
 
 /** The time between deasserting the RX_EN/TX_EN and deactivating PDN. */
-#define NRF_FEM_TRX_HOLD_TIME_IN_ADVANCE 5
+#define NRF_FEM_TRX_HOLD_US 5
 
 #ifdef NRF52811_XXAA
 /** Default Power Amplifier pin. */

--- a/src/fem/three_pin_gpio/nrf_fem_config.h
+++ b/src/fem/three_pin_gpio/nrf_fem_config.h
@@ -115,7 +115,7 @@ typedef struct
 #define NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL    16
 
 /** Default PPI channel for PDN pin handling. */
-#define NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL    17
+#define NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL    5
 
 /** Default GPIOTE channel for PDN control. */
 #define NRF_FEM_CONTROL_DEFAULT_PDN_GPIOTE_CHANNEL 5

--- a/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
+++ b/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
@@ -58,10 +58,10 @@ static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< 
 {       
     .fem_config =
     {
-        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE,
-        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE,
-        .pdn_settle_us = NRF_FEM_PDN_SETTLE_TIME_IN_ADVANCE,
-        .trx_hold_us = NRF_FEM_TRX_HOLD_TIME_IN_ADVANCE,
+        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE_US,
+        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE_US,
+        .pdn_settle_us = NRF_FEM_PDN_SETTLE_US,
+        .trx_hold_us = NRF_FEM_TRX_HOLD_US,
     },                                                              
     .pa_pin_config =
     {

--- a/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
+++ b/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
@@ -1,0 +1,527 @@
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @file
+ *   This file implements common function for Front End Module control of the nRF 802.15.4 radio driver.
+ *
+ */
+#include "nrf_fem_protocol_api.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "compiler_abstraction.h"
+#include "nrf_802154_config.h"
+#include "nrf.h"
+#include "nrf_error.h"
+#include "nrf_gpio.h"
+#include "nrf_gpiote.h"
+#include "nrf_ppi.h"
+#include "nrf_radio.h"
+#include "nrf_timer.h"
+
+
+#if ENABLE_FEM
+
+#define PPI_INVALID_CHANNEL 0xFF                                           /**< Default value for the PPI holder variable. */
+
+static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< FEM controller configuration. */
+{       
+    .fem_config =
+    {
+        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE,
+        .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE,
+        .pdn_settle_us = NRF_FEM_PDN_SETTLE_TIME_IN_ADVANCE,
+        .trx_hold_us = NRF_FEM_TRX_HOLD_TIME_IN_ADVANCE,
+    },                                                              
+    .pa_pin_config =
+    {
+        .enable = 1,
+        .active_high = 1,
+        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
+        .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL
+    },
+    .lna_pin_config =
+    {
+        .enable = 1,
+        .active_high = 1,
+        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
+        .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL
+    },
+    .pdn_pin_config =
+    {
+        .enable = 1,
+        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PDN_PIN,
+        .active_high = 1,
+        .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PDN_GPIOTE_CHANNEL
+    },
+    .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,
+    .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,
+    .ppi_ch_id_pdn = NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL
+};
+static uint8_t                    m_ppi_channel_ext           = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
+
+/** Map the mask bits with the Compare Channels. */
+static uint32_t get_available_compare_channel(uint8_t mask, uint32_t number)
+{
+    uint32_t i;
+
+    for (i = 0; i < 4; i++)
+    {
+        if (mask & (1 << i))
+        {
+            if (number == 0)
+            {
+                break;
+            }
+            else
+            {
+                number--;
+            }
+        }
+    }
+
+    if (i == 0) return NRF_TIMER_CC_CHANNEL0;
+    if (i == 1) return NRF_TIMER_CC_CHANNEL1;
+    if (i == 2) return NRF_TIMER_CC_CHANNEL2;
+    if (i == 3) return NRF_TIMER_CC_CHANNEL3;
+    assert(false);
+    return 0;
+}
+
+/** Configure GPIOTE module. */
+static void gpiote_configure(void)
+{
+    if (m_nrf_fem_interface_config.pa_pin_config.enable)
+    {
+        nrf_gpiote_task_configure(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id,
+                                  m_nrf_fem_interface_config.pa_pin_config.gpio_pin,
+                                  (nrf_gpiote_polarity_t)GPIOTE_CONFIG_POLARITY_None,
+                                  (nrf_gpiote_outinit_t) !m_nrf_fem_interface_config.pa_pin_config.active_high);
+
+        nrf_gpiote_task_enable(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id);
+    }
+
+    if (m_nrf_fem_interface_config.lna_pin_config.enable)
+    {
+        nrf_gpiote_task_configure(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id,
+                                  m_nrf_fem_interface_config.lna_pin_config.gpio_pin,
+                                  (nrf_gpiote_polarity_t)GPIOTE_CONFIG_POLARITY_None,
+                                  (nrf_gpiote_outinit_t) !m_nrf_fem_interface_config.lna_pin_config.active_high);
+
+        nrf_gpiote_task_enable(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id);
+    }
+
+    if (m_nrf_fem_interface_config.pdn_pin_config.enable)
+    {
+        nrf_gpiote_task_configure(m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id,
+                                  m_nrf_fem_interface_config.pdn_pin_config.gpio_pin,
+                                  (nrf_gpiote_polarity_t)GPIOTE_CONFIG_POLARITY_None,
+                                  (nrf_gpiote_outinit_t) !m_nrf_fem_interface_config.pdn_pin_config.active_high);
+
+        nrf_gpiote_task_enable(m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id);
+    }
+}
+
+/** Configure the event with the provided values. */
+static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_event,
+                                       nrf_fem_gpiote_pin_config_t  * p_pin_config,
+                                       bool                           activate,
+                                       uint32_t                       time_delay)
+{
+    uint32_t task_addr;
+    uint8_t  ppi_ch;
+
+    assert(p_event);
+    assert(p_pin_config);
+
+    if (p_event->override_ppi)
+    {
+        assert(p_event->ppi_ch_id != PPI_INVALID_CHANNEL);
+        if (m_ppi_channel_ext == PPI_INVALID_CHANNEL)
+        {
+            /* External PPI channel placeholder is free. */
+            m_ppi_channel_ext = ppi_ch = p_event->ppi_ch_id;
+        }
+        else if ((m_ppi_channel_ext == p_event->ppi_ch_id) &&
+                 (!NRF_PPI->FORK[(uint32_t)m_ppi_channel_ext].TEP))
+        {
+            /* PPI is equal to the already set, but the one set has a free fork endpoint. */
+            ppi_ch = p_event->ppi_ch_id;
+        }
+        else
+        {
+            return NRF_ERROR_INVALID_STATE;
+        }
+    }
+    else
+    {
+        ppi_ch =
+            activate ? m_nrf_fem_interface_config.ppi_ch_id_set : m_nrf_fem_interface_config.
+            ppi_ch_id_clr;
+    }
+
+    if (p_pin_config->active_high ^ activate)
+    {
+        task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_CLR[p_pin_config->gpiote_ch_id]);
+    }
+    else
+    {
+        task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_SET[p_pin_config->gpiote_ch_id]);
+    }
+
+    switch (p_event->type)
+    {
+        case NRF_802154_FAL_EVENT_TYPE_GENERIC:
+        {
+            if (NRF_PPI->CH[(uint32_t)ppi_ch].TEP)
+            {
+                nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)ppi_ch, task_addr);
+            }
+            else
+            {
+                nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)ppi_ch,
+                                               p_event->event.generic.register_address,
+                                               task_addr);
+            }
+
+            nrf_ppi_channel_enable((nrf_ppi_channel_t)ppi_ch);
+        }
+        break;
+
+        case NRF_802154_FAL_EVENT_TYPE_TIMER:
+        {
+            assert(p_event->event.timer.compare_channel_mask);
+
+            uint32_t compare_channel;
+
+            /* EN pin */
+            compare_channel = get_available_compare_channel(p_event->event.timer.compare_channel_mask, 0);
+            
+            nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)ppi_ch,
+                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->EVENTS_COMPARE[compare_channel])),
+                                           task_addr);
+            nrf_ppi_channel_enable((nrf_ppi_channel_t)ppi_ch);
+
+            nrf_timer_cc_write(p_event->event.timer.p_timer_instance,
+                               (nrf_timer_cc_channel_t)compare_channel,
+                               p_event->event.timer.counter_value - time_delay);
+
+
+            /* PDN pin */
+            compare_channel = get_available_compare_channel(p_event->event.timer.compare_channel_mask, 1);
+            
+            nrf_ppi_channel_endpoint_setup(m_nrf_fem_interface_config.ppi_ch_id_pdn,
+                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->EVENTS_COMPARE[compare_channel])),
+                                           (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]));
+
+            nrf_ppi_channel_enable(m_nrf_fem_interface_config.ppi_ch_id_pdn);
+
+            nrf_timer_cc_write(p_event->event.timer.p_timer_instance,
+                               (nrf_timer_cc_channel_t)compare_channel,
+                               p_event->event.timer.counter_value - time_delay - m_nrf_fem_interface_config.fem_config.pdn_settle_us);
+            break;
+        }
+
+        default:
+            assert(false);
+            break;
+    }
+
+    return NRF_SUCCESS;
+}
+
+/** Deconfigure the event with the provided values. */
+static int32_t event_configuration_clear(const nrf_802154_fal_event_t * const p_event,
+                                         bool                                 activate)
+{
+    uint8_t ppi_ch;
+
+    assert(p_event);
+
+    if (p_event->override_ppi)
+    {
+        ppi_ch = p_event->ppi_ch_id;
+    }
+    else
+    {
+        ppi_ch = activate ? m_nrf_fem_interface_config.ppi_ch_id_set : m_nrf_fem_interface_config.ppi_ch_id_clr;
+    }
+
+    nrf_ppi_channel_disable((nrf_ppi_channel_t)ppi_ch);
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)ppi_ch, 0, 0);
+    nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)ppi_ch, 0);
+
+    switch (p_event->type)
+    {
+        case NRF_802154_FAL_EVENT_TYPE_GENERIC:
+            break;
+
+        case NRF_802154_FAL_EVENT_TYPE_TIMER:
+            break;
+
+        default:
+            assert(false);
+            break;
+    }
+
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
+                                            const nrf_802154_fal_event_t * const p_deactivate_event)
+{
+    int32_t ret_code;
+
+    if (!m_nrf_fem_interface_config.pa_pin_config.enable)
+    {
+        return NRF_SUCCESS;
+    }
+
+    if (p_activate_event)
+    {
+        ret_code = event_configuration_set(p_activate_event,
+                                           &m_nrf_fem_interface_config.pa_pin_config,
+                                           true,
+                                           m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    if (p_deactivate_event)
+    {
+        ret_code = event_configuration_set(p_deactivate_event,
+                                           &m_nrf_fem_interface_config.pa_pin_config,
+                                           false,
+                                           m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
+                                             const nrf_802154_fal_event_t * const p_deactivate_event)
+{
+    int32_t ret_code;
+
+    if (!m_nrf_fem_interface_config.lna_pin_config.enable)
+    {
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    if (p_activate_event)
+    {
+        ret_code = event_configuration_set(p_activate_event,
+                                           &m_nrf_fem_interface_config.lna_pin_config,
+                                           true,
+                                           m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    if (p_deactivate_event)
+    {
+        ret_code = event_configuration_set(p_deactivate_event,
+                                           &m_nrf_fem_interface_config.lna_pin_config,
+                                           false,
+                                           m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
+                                              const nrf_802154_fal_event_t * const p_deactivate_event)
+{
+    int32_t ret_code;
+
+    if (!m_nrf_fem_interface_config.pa_pin_config.enable)
+    {
+        return NRF_ERROR_FORBIDDEN;
+    }
+
+    if (p_activate_event)
+    {
+        ret_code = event_configuration_clear(p_activate_event, true);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    if (p_deactivate_event)
+    {
+        ret_code = event_configuration_clear(p_deactivate_event, false);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+    
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_fal_lna_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
+                                               const nrf_802154_fal_event_t * const p_deactivate_event)
+{
+    int32_t ret_code;
+
+    if (!m_nrf_fem_interface_config.lna_pin_config.enable)
+    {
+        return NRF_ERROR_FORBIDDEN;
+    }
+
+    if (p_activate_event)
+    {
+        ret_code = event_configuration_clear(p_activate_event, true);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    if (p_deactivate_event)
+    {
+        ret_code = event_configuration_clear(p_deactivate_event, false);
+        if (ret_code != NRF_SUCCESS)
+        {
+            return ret_code;
+        }
+    }
+
+    return NRF_SUCCESS;
+}
+
+void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)
+{
+    if (m_nrf_fem_interface_config.pa_pin_config.enable && (type & NRF_802154_FAL_PA))
+    {
+        if (m_nrf_fem_interface_config.pa_pin_config.active_high)
+        {
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_LOW);
+        }
+        else
+        {
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+        }
+    }
+
+    if (m_nrf_fem_interface_config.lna_pin_config.enable && (type & NRF_802154_FAL_LNA))
+    {
+        if (m_nrf_fem_interface_config.lna_pin_config.active_high)
+        {
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_LOW);
+        }
+        else
+        {
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+        }
+    }
+}
+
+int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * const p_config)
+{
+    m_nrf_fem_interface_config = *p_config;
+
+    if (m_nrf_fem_interface_config.pa_pin_config.enable ||
+        m_nrf_fem_interface_config.lna_pin_config.enable)
+    {
+        gpiote_configure();
+    }
+
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_config)
+{
+    *p_config = m_nrf_fem_interface_config;
+
+    return NRF_SUCCESS;
+}
+
+void nrf_802154_fal_cleanup(void)
+{
+    nrf_ppi_channel_disable((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_set);
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_set, 0,
+                                   0);
+    nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_set, 0);
+    nrf_ppi_channel_disable((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_clr);
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_clr, 0,
+                                   0);
+    nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)m_nrf_fem_interface_config.ppi_ch_id_clr, 0);
+    if (m_ppi_channel_ext != PPI_INVALID_CHANNEL)
+    {
+        nrf_ppi_channel_disable((nrf_ppi_channel_t)m_ppi_channel_ext);
+        nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)m_ppi_channel_ext, 0, 0);
+        nrf_ppi_fork_endpoint_setup((nrf_ppi_channel_t)m_ppi_channel_ext, 0);
+        m_ppi_channel_ext = PPI_INVALID_CHANNEL;
+    }
+}
+
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+{
+    if (!m_nrf_fem_interface_config.pdn_pin_config.enable)
+    {
+        return false;
+    }
+
+    nrf_timer_cc_write(p_instance, compare_channel, m_nrf_fem_interface_config.fem_config.trx_hold_us + 1);
+    nrf_ppi_channel_endpoint_setup(m_nrf_fem_interface_config.ppi_ch_id_pdn,
+                                   (uint32_t)(&(p_instance->EVENTS_COMPARE[compare_channel])),
+                                   (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]));
+
+    uint32_t event_addr = (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_DISABLED);
+    uint32_t task_addr = (uint32_t)nrf_timer_task_address_get(p_instance, NRF_TIMER_TASK_START);
+
+    nrf_timer_shorts_enable(p_instance, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+    nrf_ppi_channel_endpoint_setup(ppi_id, event_addr, task_addr);
+    nrf_ppi_fork_endpoint_setup(ppi_id, 0);
+    nrf_ppi_channel_enable(ppi_id);
+
+    nrf_timer_event_clear(p_instance, NRF_TIMER_EVENT_COMPARE0);
+
+    return true;
+}
+
+#endif // ENABLE_FEM

--- a/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
+++ b/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
@@ -49,46 +49,45 @@
 #include "nrf_radio.h"
 #include "nrf_timer.h"
 
-
 #if ENABLE_FEM
 
-#define PPI_INVALID_CHANNEL 0xFF                                           /**< Default value for the PPI holder variable. */
+#define PPI_INVALID_CHANNEL 0xFF                               /**< Default value for the PPI holder variable. */
 
-static nrf_fem_interface_config_t m_nrf_fem_interface_config =             /**< FEM controller configuration. */
-{       
+static nrf_fem_interface_config_t m_nrf_fem_interface_config = /**< FEM controller configuration. */
+{
     .fem_config =
     {
-        .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE_US,
+        .pa_time_gap_us  = NRF_FEM_PA_TIME_IN_ADVANCE_US,
         .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE_US,
-        .pdn_settle_us = NRF_FEM_PDN_SETTLE_US,
-        .trx_hold_us = NRF_FEM_TRX_HOLD_US,
-    },                                                              
+        .pdn_settle_us   = NRF_FEM_PDN_SETTLE_US,
+        .trx_hold_us     = NRF_FEM_TRX_HOLD_US,
+    },
     .pa_pin_config =
     {
-        .enable = 1,
-        .active_high = 1,
-        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
+        .enable       = 1,
+        .active_high  = 1,
+        .gpio_pin     = NRF_FEM_CONTROL_DEFAULT_PA_PIN,
         .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL
     },
     .lna_pin_config =
     {
-        .enable = 1,
-        .active_high = 1,
-        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
+        .enable       = 1,
+        .active_high  = 1,
+        .gpio_pin     = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,
         .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL
     },
     .pdn_pin_config =
     {
-        .enable = 1,
-        .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PDN_PIN,
-        .active_high = 1,
+        .enable       = 1,
+        .gpio_pin     = NRF_FEM_CONTROL_DEFAULT_PDN_PIN,
+        .active_high  = 1,
         .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PDN_GPIOTE_CHANNEL
     },
     .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,
     .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,
     .ppi_ch_id_pdn = NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL
 };
-static uint8_t                    m_ppi_channel_ext           = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
+static uint8_t m_ppi_channel_ext = PPI_INVALID_CHANNEL; /**< PPI channel provided by the `override_ppi = true` functionality. */
 
 /** Map the mask bits with the Compare Channels. */
 static uint32_t get_available_compare_channel(uint8_t mask, uint32_t number)
@@ -110,10 +109,14 @@ static uint32_t get_available_compare_channel(uint8_t mask, uint32_t number)
         }
     }
 
-    if (i == 0) return NRF_TIMER_CC_CHANNEL0;
-    if (i == 1) return NRF_TIMER_CC_CHANNEL1;
-    if (i == 2) return NRF_TIMER_CC_CHANNEL2;
-    if (i == 3) return NRF_TIMER_CC_CHANNEL3;
+    if (i == 0)
+        return NRF_TIMER_CC_CHANNEL0;
+    if (i == 1)
+        return NRF_TIMER_CC_CHANNEL1;
+    if (i == 2)
+        return NRF_TIMER_CC_CHANNEL2;
+    if (i == 3)
+        return NRF_TIMER_CC_CHANNEL3;
     assert(false);
     return 0;
 }
@@ -154,9 +157,9 @@ static void gpiote_configure(void)
 
 /** Configure the event with the provided values. */
 static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_event,
-                                       nrf_fem_gpiote_pin_config_t  * p_pin_config,
-                                       bool                           activate,
-                                       uint32_t                       time_delay)
+                                       nrf_fem_gpiote_pin_config_t        * p_pin_config,
+                                       bool                                 activate,
+                                       uint32_t                             time_delay)
 {
     uint32_t task_addr;
     uint8_t  ppi_ch;
@@ -226,10 +229,13 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
             uint32_t pdn_task_addr;
 
             /* EN pin */
-            compare_channel = get_available_compare_channel(p_event->event.timer.compare_channel_mask, 0);
-            
+            compare_channel = get_available_compare_channel(
+                p_event->event.timer.compare_channel_mask,
+                0);
+
             nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)ppi_ch,
-                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->EVENTS_COMPARE[compare_channel])),
+                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->
+                                                        EVENTS_COMPARE[compare_channel])),
                                            task_addr);
             nrf_ppi_channel_enable((nrf_ppi_channel_t)ppi_ch);
 
@@ -237,28 +243,35 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
                                (nrf_timer_cc_channel_t)compare_channel,
                                p_event->event.timer.counter_value - time_delay);
 
-
             /* PDN pin */
             if (m_nrf_fem_interface_config.pdn_pin_config.active_high)
             {
-                pdn_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]);
+                pdn_task_addr =
+                    (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_interface_config.pdn_pin_config.
+                                                      gpiote_ch_id]);
             }
             else
             {
-                pdn_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]);
+                pdn_task_addr =
+                    (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_interface_config.pdn_pin_config.
+                                                      gpiote_ch_id]);
             }
 
-            compare_channel = get_available_compare_channel(p_event->event.timer.compare_channel_mask, 1);
-            
+            compare_channel = get_available_compare_channel(
+                p_event->event.timer.compare_channel_mask,
+                1);
+
             nrf_ppi_channel_endpoint_setup(m_nrf_fem_interface_config.ppi_ch_id_pdn,
-                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->EVENTS_COMPARE[compare_channel])),
+                                           (uint32_t)(&(p_event->event.timer.p_timer_instance->
+                                                        EVENTS_COMPARE[compare_channel])),
                                            pdn_task_addr);
 
             nrf_ppi_channel_enable(m_nrf_fem_interface_config.ppi_ch_id_pdn);
 
             nrf_timer_cc_write(p_event->event.timer.p_timer_instance,
                                (nrf_timer_cc_channel_t)compare_channel,
-                               p_event->event.timer.counter_value - time_delay - m_nrf_fem_interface_config.fem_config.pdn_settle_us);
+                               p_event->event.timer.counter_value - time_delay -
+                               m_nrf_fem_interface_config.fem_config.pdn_settle_us);
             break;
         }
 
@@ -284,7 +297,9 @@ static int32_t event_configuration_clear(const nrf_802154_fal_event_t * const p_
     }
     else
     {
-        ppi_ch = activate ? m_nrf_fem_interface_config.ppi_ch_id_set : m_nrf_fem_interface_config.ppi_ch_id_clr;
+        ppi_ch =
+            activate ? m_nrf_fem_interface_config.ppi_ch_id_set : m_nrf_fem_interface_config.
+            ppi_ch_id_clr;
     }
 
     nrf_ppi_channel_disable((nrf_ppi_channel_t)ppi_ch);
@@ -406,12 +421,13 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
             return ret_code;
         }
     }
-    
+
     return NRF_SUCCESS;
 }
 
-int32_t nrf_802154_fal_lna_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
-                                               const nrf_802154_fal_event_t * const p_deactivate_event)
+int32_t nrf_802154_fal_lna_configuration_clear(
+    const nrf_802154_fal_event_t * const p_activate_event,
+    const nrf_802154_fal_event_t * const p_deactivate_event)
 {
     int32_t ret_code;
 
@@ -447,11 +463,13 @@ void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)
     {
         if (m_nrf_fem_interface_config.pa_pin_config.active_high)
         {
-            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_LOW);
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id,
+                                  NRF_GPIOTE_INITIAL_VALUE_LOW);
         }
         else
         {
-            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.pa_pin_config.gpiote_ch_id,
+                                  NRF_GPIOTE_INITIAL_VALUE_HIGH);
         }
     }
 
@@ -459,11 +477,13 @@ void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)
     {
         if (m_nrf_fem_interface_config.lna_pin_config.active_high)
         {
-            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_LOW);
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id,
+                                  NRF_GPIOTE_INITIAL_VALUE_LOW);
         }
         else
         {
-            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id, NRF_GPIOTE_INITIAL_VALUE_HIGH);
+            nrf_gpiote_task_force(m_nrf_fem_interface_config.lna_pin_config.gpiote_ch_id,
+                                  NRF_GPIOTE_INITIAL_VALUE_HIGH);
         }
     }
 }
@@ -507,7 +527,9 @@ void nrf_802154_fal_cleanup(void)
     }
 }
 
-bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_channel, nrf_ppi_channel_t ppi_id)
+bool nrf_fem_prepare_powerdown(NRF_TIMER_Type  * p_instance,
+                               uint32_t          compare_channel,
+                               nrf_ppi_channel_t ppi_id)
 {
     uint32_t pdn_task_addr;
 
@@ -518,20 +540,26 @@ bool nrf_fem_prepare_powerdown(NRF_TIMER_Type * p_instance, uint32_t compare_cha
 
     if (m_nrf_fem_interface_config.pdn_pin_config.active_high)
     {
-        pdn_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]);
+        pdn_task_addr =
+            (uint32_t)(&NRF_GPIOTE->TASKS_CLR[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id
+                       ]);
     }
     else
     {
-        pdn_task_addr = (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id]);
+        pdn_task_addr =
+            (uint32_t)(&NRF_GPIOTE->TASKS_SET[m_nrf_fem_interface_config.pdn_pin_config.gpiote_ch_id
+                       ]);
     }
 
-    nrf_timer_cc_write(p_instance, compare_channel, m_nrf_fem_interface_config.fem_config.trx_hold_us + 1);
+    nrf_timer_cc_write(p_instance,
+                       compare_channel,
+                       m_nrf_fem_interface_config.fem_config.trx_hold_us + 1);
     nrf_ppi_channel_endpoint_setup(m_nrf_fem_interface_config.ppi_ch_id_pdn,
                                    (uint32_t)(&(p_instance->EVENTS_COMPARE[compare_channel])),
                                    pdn_task_addr);
 
     uint32_t event_addr = (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_DISABLED);
-    uint32_t task_addr = (uint32_t)nrf_timer_task_address_get(p_instance, NRF_TIMER_TASK_START);
+    uint32_t task_addr  = (uint32_t)nrf_timer_task_address_get(p_instance, NRF_TIMER_TASK_START);
 
     nrf_timer_shorts_enable(p_instance, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     nrf_ppi_channel_endpoint_setup(ppi_id, event_addr, task_addr);

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -244,20 +244,11 @@ void nrf_802154_radio_irq_handler(void)
 #if ENABLE_FEM
 void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p_cfg)
 {
-    nrf_fem_interface_config_t config = NRF_802154_FAL_DEFAULT_SETTINGS;
+    nrf_fem_interface_config_t config;
+    nrf_fem_interface_configuration_get(&config);
 
-    config.lna_pin_config.active_high  = p_cfg->lna_cfg.active_high;
-    config.lna_pin_config.enable       = p_cfg->lna_cfg.enable;
-    config.lna_pin_config.gpio_pin     = p_cfg->lna_cfg.gpio_pin;
-    config.lna_pin_config.gpiote_ch_id = p_cfg->lna_gpiote_ch_id;
-
-    config.pa_pin_config.active_high  = p_cfg->pa_cfg.active_high;
-    config.pa_pin_config.enable       = p_cfg->pa_cfg.enable;
-    config.pa_pin_config.gpio_pin     = p_cfg->pa_cfg.gpio_pin;
-    config.pa_pin_config.gpiote_ch_id = p_cfg->pa_gpiote_ch_id;
-
-    config.ppi_ch_id_set = p_cfg->ppi_ch_id_set;
-    config.ppi_ch_id_clr = p_cfg->ppi_ch_id_clr;
+    config.lna_pin_config.enable = p_cfg->lna_cfg.enable;
+    config.pa_pin_config.enable  = p_cfg->pa_cfg.enable;
 
     nrf_fem_interface_configuration_set(&config);
 }
@@ -265,22 +256,10 @@ void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p
 void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg)
 {
     nrf_fem_interface_config_t config;
-
     nrf_fem_interface_configuration_get(&config);
 
-    p_cfg->lna_cfg.active_high = config.lna_pin_config.active_high;
-    p_cfg->lna_cfg.enable      = config.lna_pin_config.enable;
-    p_cfg->lna_cfg.gpio_pin    = config.lna_pin_config.gpio_pin;
-
-    p_cfg->pa_cfg.active_high = config.pa_pin_config.active_high;
-    p_cfg->pa_cfg.enable      = config.pa_pin_config.enable;
-    p_cfg->pa_cfg.gpio_pin    = config.pa_pin_config.gpio_pin;
-
-    p_cfg->lna_gpiote_ch_id = config.lna_pin_config.gpiote_ch_id;
-    p_cfg->pa_gpiote_ch_id  = config.pa_pin_config.gpiote_ch_id;
-
-    p_cfg->ppi_ch_id_clr = config.ppi_ch_id_clr;
-    p_cfg->ppi_ch_id_set = config.ppi_ch_id_set;
+    p_cfg->lna_cfg.enable = config.lna_pin_config.enable;
+    p_cfg->pa_cfg.enable  = config.pa_pin_config.enable;
 }
 
 #endif // ENABLE_FEM

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -246,6 +246,8 @@ void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p
 {
     nrf_fem_interface_config_t config;
 
+    nrf_fem_interface_configuration_get(&config);
+
     config.lna_pin_config.active_high  = p_cfg->lna_cfg.active_high;
     config.lna_pin_config.enable       = p_cfg->lna_cfg.enable;
     config.lna_pin_config.gpio_pin     = p_cfg->lna_cfg.gpio_pin;

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -245,7 +245,7 @@ void nrf_802154_radio_irq_handler(void)
 void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p_cfg)
 {
     nrf_fem_interface_config_t config;
-    
+
     config.lna_pin_config.active_high  = p_cfg->lna_cfg.active_high;
     config.lna_pin_config.enable       = p_cfg->lna_cfg.enable;
     config.lna_pin_config.gpio_pin     = p_cfg->lna_cfg.gpio_pin;
@@ -265,6 +265,7 @@ void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p
 void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg)
 {
     nrf_fem_interface_config_t config;
+
     nrf_fem_interface_configuration_get(&config);
 
     p_cfg->lna_cfg.active_high = config.lna_pin_config.active_high;

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -245,10 +245,19 @@ void nrf_802154_radio_irq_handler(void)
 void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p_cfg)
 {
     nrf_fem_interface_config_t config;
-    nrf_fem_interface_configuration_get(&config);
+    
+    config.lna_pin_config.active_high  = p_cfg->lna_cfg.active_high;
+    config.lna_pin_config.enable       = p_cfg->lna_cfg.enable;
+    config.lna_pin_config.gpio_pin     = p_cfg->lna_cfg.gpio_pin;
+    config.lna_pin_config.gpiote_ch_id = p_cfg->lna_gpiote_ch_id;
 
-    config.lna_pin_config.enable = p_cfg->lna_cfg.enable;
-    config.pa_pin_config.enable  = p_cfg->pa_cfg.enable;
+    config.pa_pin_config.active_high  = p_cfg->pa_cfg.active_high;
+    config.pa_pin_config.enable       = p_cfg->pa_cfg.enable;
+    config.pa_pin_config.gpio_pin     = p_cfg->pa_cfg.gpio_pin;
+    config.pa_pin_config.gpiote_ch_id = p_cfg->pa_gpiote_ch_id;
+
+    config.ppi_ch_id_set = p_cfg->ppi_ch_id_set;
+    config.ppi_ch_id_clr = p_cfg->ppi_ch_id_clr;
 
     nrf_fem_interface_configuration_set(&config);
 }
@@ -258,8 +267,19 @@ void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg)
     nrf_fem_interface_config_t config;
     nrf_fem_interface_configuration_get(&config);
 
-    p_cfg->lna_cfg.enable = config.lna_pin_config.enable;
-    p_cfg->pa_cfg.enable  = config.pa_pin_config.enable;
+    p_cfg->lna_cfg.active_high = config.lna_pin_config.active_high;
+    p_cfg->lna_cfg.enable      = config.lna_pin_config.enable;
+    p_cfg->lna_cfg.gpio_pin    = config.lna_pin_config.gpio_pin;
+
+    p_cfg->pa_cfg.active_high = config.pa_pin_config.active_high;
+    p_cfg->pa_cfg.enable      = config.pa_pin_config.enable;
+    p_cfg->pa_cfg.gpio_pin    = config.pa_pin_config.gpio_pin;
+
+    p_cfg->lna_gpiote_ch_id = config.lna_pin_config.gpiote_ch_id;
+    p_cfg->pa_gpiote_ch_id  = config.pa_pin_config.gpiote_ch_id;
+
+    p_cfg->ppi_ch_id_clr = config.ppi_ch_id_clr;
+    p_cfg->ppi_ch_id_set = config.ppi_ch_id_set;
 }
 
 #endif // ENABLE_FEM

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -134,10 +134,18 @@ typedef nrf_fem_control_cfg_t nrf_802154_fem_control_cfg_t;
     ((nrf_802154_fem_control_cfg_t) {                                   \
         .pa_cfg = {                                                     \
             .enable = 1,                                                \
+            .active_high = 1,                                           \
+            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,                 \
         },                                                              \
         .lna_cfg = {                                                    \
             .enable = 1,                                                \
+            .active_high = 1,                                           \
+            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,                \
         },                                                              \
+        .pa_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL,   \
+        .lna_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL, \
+        .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,       \
+        .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,       \
     })
 
 /**
@@ -145,6 +153,9 @@ typedef nrf_fem_control_cfg_t nrf_802154_fem_control_cfg_t;
  *
  * @note This function must not be called when the radio is in use.
  *
+ * @note This function is deprecated. Only to be used with Skyworks module.
+ *       Consider using nrf_fem_interface_configuration_set instead.
+ * 
  * @param[in] p_cfg Pointer to the PA & LNA GPIO toggle configuration.
  *
  */
@@ -154,6 +165,9 @@ void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p
  * @brief Get the PA & LNA GPIO toggle configuration.
  *
  * @param[out] p_cfg Pointer to the structure for the PA & LNA GPIO toggle configuration.
+ *
+ * @note This function is deprecated. Only to be used with Skyworks module.
+ *       Consider using nrf_fem_interface_configuration_get instead.
  *
  */
 void nrf_802154_fem_control_cfg_get(nrf_802154_fem_control_cfg_t * p_cfg);

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -155,7 +155,7 @@ typedef nrf_fem_control_cfg_t nrf_802154_fem_control_cfg_t;
  *
  * @note This function is deprecated. Only to be used with Skyworks module.
  *       Consider using nrf_fem_interface_configuration_set instead.
- * 
+ *
  * @param[in] p_cfg Pointer to the PA & LNA GPIO toggle configuration.
  *
  */

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -134,40 +134,10 @@ typedef nrf_fem_control_cfg_t nrf_802154_fem_control_cfg_t;
     ((nrf_802154_fem_control_cfg_t) {                                   \
         .pa_cfg = {                                                     \
             .enable = 1,                                                \
-            .active_high = 1,                                           \
-            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,                 \
         },                                                              \
         .lna_cfg = {                                                    \
             .enable = 1,                                                \
-            .active_high = 1,                                           \
-            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,                \
         },                                                              \
-        .pa_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL,   \
-        .lna_gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL, \
-        .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,       \
-        .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,       \
-    })
-
-#define NRF_802154_FAL_DEFAULT_SETTINGS                                \
-    ((nrf_fem_interface_config_t) {                                    \
-        .fem_config = {                                                \
-            .pa_time_gap_us = NRF_FEM_PA_TIME_IN_ADVANCE,              \
-            .lna_time_gap_us = NRF_FEM_LNA_TIME_IN_ADVANCE             \
-        },                                                             \
-        .pa_pin_config = {                                             \
-            .enable = 1,                                               \
-            .active_high = 1,                                          \
-            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_PA_PIN,                \
-            .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  \
-        },                                                             \
-        .lna_pin_config = {                                            \
-            .enable = 1,                                               \
-            .active_high = 1,                                          \
-            .gpio_pin = NRF_FEM_CONTROL_DEFAULT_LNA_PIN,               \
-            .gpiote_ch_id = NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL \
-        },                                                             \
-        .ppi_ch_id_set = NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL,      \
-        .ppi_ch_id_clr = NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL,      \
     })
 
 /**

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -191,20 +191,18 @@ static const nrf_802154_fal_event_t m_activate_rx_cc0 =
  .override_ppi                 = false,
  .event.timer.p_timer_instance =
      NRF_802154_TIMER_INSTANCE,
- .event.timer.compare_channel_mask = 1 <<
-                                     NRF_TIMER_CC_CHANNEL0,
+ .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
         .event.timer.counter_value =
-         NRF_FEM_RADIO_RX_STARTUP_LATENCY_US};
+         RX_RAMP_UP_TIME};
 
 static const nrf_802154_fal_event_t m_activate_tx_cc0 =
 {.type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
  .override_ppi                 = false,
  .event.timer.p_timer_instance =
      NRF_802154_TIMER_INSTANCE,
- .event.timer.compare_channel_mask = 1 <<
-                                     NRF_TIMER_CC_CHANNEL0,
+ .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
         .event.timer.counter_value =
-         NRF_FEM_RADIO_TX_STARTUP_LATENCY_US};
+         TX_RAMP_UP_TIME};
 
 static const nrf_802154_fal_event_t m_ccaidle =
 {.type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
@@ -1077,7 +1075,18 @@ static void rx_terminate(void)
         ints_to_disable |= NRF_RADIO_INT_CRCOK_MASK;
         nrf_radio_int_disable(ints_to_disable);
         nrf_radio_shorts_set(SHORTS_IDLE);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
+        if (shutdown)
+        {
+            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            {
+                // Wait until the event is set.
+            }
+            nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+            nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+            nrf_ppi_channel_disable(PPI_EGU_TIMER_START);
+        }
     }
 }
 
@@ -1151,8 +1160,19 @@ static void tx_terminate(void)
 
         nrf_radio_int_disable(ints_to_disable);
         nrf_radio_shorts_set(SHORTS_IDLE);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
         nrf_radio_task_trigger(NRF_RADIO_TASK_CCASTOP);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
+        if (shutdown)
+        {
+            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            {
+                // Wait until the event is set.
+            }
+            nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+            nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+            nrf_ppi_channel_disable(PPI_EGU_TIMER_START);
+        }
     }
 }
 
@@ -1195,10 +1215,23 @@ static void ed_terminate(void)
 
     if (timeslot_is_granted())
     {
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+
         nrf_radio_int_disable(NRF_RADIO_INT_EDEND_MASK);
         nrf_radio_shorts_set(SHORTS_IDLE);
         nrf_radio_task_trigger(NRF_RADIO_TASK_EDSTOP);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
+
+        if (shutdown)
+        {
+            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            {
+                // Wait until the event is set.
+            }
+            nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+            nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+            nrf_ppi_channel_disable(PPI_EGU_TIMER_START);
+        }
     }
 }
 
@@ -1215,10 +1248,23 @@ static void cca_terminate(void)
 
     if (timeslot_is_granted())
     {
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+
         nrf_radio_int_disable(NRF_RADIO_INT_CCABUSY_MASK | NRF_RADIO_INT_CCAIDLE_MASK);
         nrf_radio_shorts_set(SHORTS_IDLE);
         nrf_radio_task_trigger(NRF_RADIO_TASK_CCASTOP);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
+
+        if (shutdown)
+        {
+            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            {
+                // Wait until the event is set.
+            }
+            nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+            nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+            nrf_ppi_channel_disable(PPI_EGU_TIMER_START);
+        }
     }
 }
 
@@ -1232,7 +1278,19 @@ static void continuous_carrier_terminate(void)
 
     if (timeslot_is_granted())
     {
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
+        if (shutdown)
+        {
+            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            {
+                // Wait until the event is set.
+            }
+            nrf_timer_shorts_disable(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
+            nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+            nrf_ppi_channel_disable(PPI_EGU_TIMER_START);
+        }
     }
 }
 
@@ -1477,7 +1535,6 @@ static void rx_init(bool disabled_was_triggered)
                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     uint32_t delta_time;
-
     if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRF_SUCCESS)
     {
         delta_time = nrf_timer_cc_read(NRF_802154_TIMER_INSTANCE,

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -192,8 +192,8 @@ static const nrf_802154_fal_event_t m_activate_rx_cc0 =
  .event.timer.p_timer_instance =
      NRF_802154_TIMER_INSTANCE,
  .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
-        .event.timer.counter_value =
-         RX_RAMP_UP_TIME};
+ .event.timer.counter_value        =
+     RX_RAMP_UP_TIME};
 
 static const nrf_802154_fal_event_t m_activate_tx_cc0 =
 {.type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
@@ -201,8 +201,8 @@ static const nrf_802154_fal_event_t m_activate_tx_cc0 =
  .event.timer.p_timer_instance =
      NRF_802154_TIMER_INSTANCE,
  .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
-        .event.timer.counter_value =
-         TX_RAMP_UP_TIME};
+ .event.timer.counter_value        =
+     TX_RAMP_UP_TIME};
 
 static const nrf_802154_fal_event_t m_ccaidle =
 {.type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
@@ -1075,11 +1075,14 @@ static void rx_terminate(void)
         ints_to_disable |= NRF_RADIO_INT_CRCOK_MASK;
         nrf_radio_int_disable(ints_to_disable);
         nrf_radio_shorts_set(SHORTS_IDLE);
-        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE,
+                                                  NRF_TIMER_CC_CHANNEL0,
+                                                  PPI_EGU_TIMER_START);
+
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
         if (shutdown)
         {
-            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            while (!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
             {
                 // Wait until the event is set.
             }
@@ -1160,12 +1163,15 @@ static void tx_terminate(void)
 
         nrf_radio_int_disable(ints_to_disable);
         nrf_radio_shorts_set(SHORTS_IDLE);
-        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE,
+                                                  NRF_TIMER_CC_CHANNEL0,
+                                                  PPI_EGU_TIMER_START);
+
         nrf_radio_task_trigger(NRF_RADIO_TASK_CCASTOP);
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
         if (shutdown)
         {
-            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            while (!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
             {
                 // Wait until the event is set.
             }
@@ -1215,7 +1221,9 @@ static void ed_terminate(void)
 
     if (timeslot_is_granted())
     {
-        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE,
+                                                  NRF_TIMER_CC_CHANNEL0,
+                                                  PPI_EGU_TIMER_START);
 
         nrf_radio_int_disable(NRF_RADIO_INT_EDEND_MASK);
         nrf_radio_shorts_set(SHORTS_IDLE);
@@ -1224,7 +1232,7 @@ static void ed_terminate(void)
 
         if (shutdown)
         {
-            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            while (!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
             {
                 // Wait until the event is set.
             }
@@ -1248,7 +1256,9 @@ static void cca_terminate(void)
 
     if (timeslot_is_granted())
     {
-        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE,
+                                                  NRF_TIMER_CC_CHANNEL0,
+                                                  PPI_EGU_TIMER_START);
 
         nrf_radio_int_disable(NRF_RADIO_INT_CCABUSY_MASK | NRF_RADIO_INT_CCAIDLE_MASK);
         nrf_radio_shorts_set(SHORTS_IDLE);
@@ -1257,7 +1267,7 @@ static void cca_terminate(void)
 
         if (shutdown)
         {
-            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            while (!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
             {
                 // Wait until the event is set.
             }
@@ -1278,12 +1288,14 @@ static void continuous_carrier_terminate(void)
 
     if (timeslot_is_granted())
     {
-        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START);
+        bool shutdown = nrf_fem_prepare_powerdown(NRF_802154_TIMER_INSTANCE,
+                                                  NRF_TIMER_CC_CHANNEL0,
+                                                  PPI_EGU_TIMER_START);
 
         nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
         if (shutdown)
         {
-            while(!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
+            while (!nrf_timer_event_check(NRF_802154_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0))
             {
                 // Wait until the event is set.
             }
@@ -1535,6 +1547,7 @@ static void rx_init(bool disabled_was_triggered)
                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     uint32_t delta_time;
+
     if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRF_SUCCESS)
     {
         delta_time = nrf_timer_cc_read(NRF_802154_TIMER_INSTANCE,

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -62,7 +62,6 @@ static void radio_event_gpio_toggle_init(void)
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_READY);
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_FRAMESTART);
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_EDEND);
-    nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_PHYEND);
 
     nrf_gpiote_task_configure(0,
                               PIN_DBG_RADIO_EVT_END,
@@ -84,17 +83,12 @@ static void radio_event_gpio_toggle_init(void)
                               PIN_DBG_RADIO_EVT_EDEND,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(5,
-                              PIN_DBG_RADIO_EVT_PHYEND,
-                              NRF_GPIOTE_POLARITY_TOGGLE,
-                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
 
     nrf_gpiote_task_enable(0);
     nrf_gpiote_task_enable(1);
     nrf_gpiote_task_enable(2);
     nrf_gpiote_task_enable(3);
     nrf_gpiote_task_enable(4);
-    nrf_gpiote_task_enable(5);
 
     nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0,
                                    (uint32_t)&NRF_RADIO->EVENTS_END,
@@ -111,16 +105,12 @@ static void radio_event_gpio_toggle_init(void)
     nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL4,
                                    (uint32_t)&NRF_RADIO->EVENTS_EDEND,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_4));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5,
-                                   (uint32_t)&NRF_RADIO->EVENTS_PHYEND,
-                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
 
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL0);
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL1);
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL2);
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL3);
     nrf_ppi_channel_enable(NRF_PPI_CHANNEL4);
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL5);
 }
 
 /**

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -124,36 +124,6 @@ static void raal_simulator_gpio_init(void)
 #endif
 }
 
-/**
- * @brief Initialize PPI to toggle GPIO pins on Softdevice events. Initialize GPIO to set it
- *        according to Softdevice arbiter client events.
- */
-static void raal_softdevice_event_gpio_toggle_init(void)
-{
-#if RAAL_SOFTDEVICE
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_ACTIVE);
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_EXTEND_REQ);
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_SESSION_IDLE);
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_RADIO_IRQ);
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_FAILED);
-    nrf_gpio_cfg_output(PIN_DBG_TIMESLOT_BLOCKED);
-    nrf_gpio_cfg_output(PIN_DBG_RTC0_EVT_REM);
-
-    nrf_gpiote_task_configure(5,
-                              PIN_DBG_RTC0_EVT_REM,
-                              NRF_GPIOTE_POLARITY_TOGGLE,
-                              NRF_GPIOTE_INITIAL_VALUE_HIGH);
-
-    nrf_gpiote_task_enable(5);
-
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL5,
-                                   (uint32_t)&NRF_RTC0->EVENTS_COMPARE[1],
-                                   nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_5));
-
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL5);
-#endif // RAAL_SOFTDEVICE
-}
-
 #endif // ENABLE_DEBUG_GPIO
 
 void nrf_802154_debug_init(void)
@@ -161,7 +131,6 @@ void nrf_802154_debug_init(void)
 #if ENABLE_DEBUG_GPIO
     radio_event_gpio_toggle_init();
     raal_simulator_gpio_init();
-    raal_softdevice_event_gpio_toggle_init();
 #endif // ENABLE_DEBUG_GPIO
 }
 

--- a/test/unit tests/fsm_cca/unity_test.c
+++ b/test/unit tests/fsm_cca/unity_test.c
@@ -330,6 +330,7 @@ static void verify_cca_terminate_periph_reset(bool in_timeslot)
 
     if (in_timeslot)
     {
+        nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
         nrf_radio_int_disable_Expect(NRF_RADIO_INT_CCAIDLE_MASK | NRF_RADIO_INT_CCABUSY_MASK);
         nrf_radio_shorts_set_Expect(0);
         nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_CCASTOP);

--- a/test/unit tests/fsm_cont_carrier/unity_test.c
+++ b/test/unit tests/fsm_cont_carrier/unity_test.c
@@ -217,6 +217,7 @@ void test_continuous_carrier_terminate_ShallResetPeriphAndTriggerDisableTask(voi
 
     m_rsch_timeslot_is_granted = true;
 
+    nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
     nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
 
     continuous_carrier_terminate();

--- a/test/unit tests/fsm_ed/unity_test.c
+++ b/test/unit tests/fsm_ed/unity_test.c
@@ -332,6 +332,7 @@ static void verify_ed_terminate_periph_reset(bool is_in_timeslot)
 
     if (is_in_timeslot)
     {
+        nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
         nrf_radio_int_disable_Expect(NRF_RADIO_INT_EDEND_MASK);
         nrf_radio_shorts_set_Expect(0);
         nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_EDSTOP);

--- a/test/unit tests/fsm_frame_filtering/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering/unity_test.c
@@ -209,6 +209,7 @@ static void mock_rx_terminate(void)
                                  NRF_RADIO_INT_CRCERROR_MASK |
                                  NRF_RADIO_INT_CRCOK_MASK);
     nrf_radio_shorts_set_Expect(0);
+    nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
     nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
 }
 
@@ -261,6 +262,7 @@ static void mock_tx_terminate(void)
                                  NRF_RADIO_INT_CCABUSY_MASK |
                                  NRF_RADIO_INT_ADDRESS_MASK);
     nrf_radio_shorts_set_Expect(SHORTS_IDLE);
+    nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
     nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_CCASTOP);
     nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
 }

--- a/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
@@ -189,6 +189,7 @@ static void mock_rx_terminate(void)
 
     nrf_radio_int_disable_Expect(NRF_RADIO_INT_CRCOK_MASK | NRF_RADIO_INT_CRCERROR_MASK);
     nrf_radio_shorts_set_Expect(0);
+    nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
     nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
 }
 

--- a/test/unit tests/fsm_rx/unity_test.c
+++ b/test/unit tests/fsm_rx/unity_test.c
@@ -461,6 +461,7 @@ static inline void rx_terminate_periph_reset_verify(bool timeslot_granted)
                                      NRF_RADIO_INT_BCMATCH_MASK  |
                                      NRF_RADIO_INT_CRCOK_MASK);
         nrf_radio_shorts_set_Expect(0);
+        nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
         nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
     }
 }

--- a/test/unit tests/fsm_tx/unity_test.c
+++ b/test/unit tests/fsm_tx/unity_test.c
@@ -581,6 +581,7 @@ static void verify_tx_terminate_periph_reset(bool in_timeslot)
                                      NRF_RADIO_INT_PHYEND_MASK  |
                                      NRF_RADIO_INT_ADDRESS_MASK);
         nrf_radio_shorts_set_Expect(0);
+        nrf_fem_prepare_powerdown_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, PPI_EGU_TIMER_START, false);
         nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_CCASTOP);
         nrf_radio_task_trigger_Expect(NRF_RADIO_TASK_DISABLE);
     }


### PR DESCRIPTION
Introduce the support for the 3-pin frontend module. The configuration of the module assumes one pin to steer the powering of the module  and two pins to enable/disable PA and LNA. Also some rework of the internals to support choosing the desired frontend module at the linkage stage.