### PR TITLE
Peripheral usage information moved to a single header file

### DIFF
--- a/src/fem/nrf_fem_control_config.h
+++ b/src/fem/nrf_fem_control_config.h
@@ -38,6 +38,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "nrf_error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -288,6 +288,10 @@ static inline void nrf_802154_fal_pa_is_configured(int8_t * const p_gain)
     *p_gain = 0;
 }
 
+#define NRF_802154_FEM_PINS_USED_MASK            0
+#define NRF_802154_FEM_PPI_CHANNELS_USED_MASK    0
+#define NRF_802154_FEM_GPIOTE_CHANNELS_USED_MASK 0
+
 #endif // ENABLE_FEM
 
 #endif // NRF_FEM_PROTOCOL_API_H__

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -49,6 +49,7 @@
 #include "nrf_fem_control_config.h"
 #include "nrf_fem_protocol_legacy_api.h"
 
+#include "nrf_error.h"
 #include "nrf_ppi.h"
 #include "nrf_timer.h"
 

--- a/src/fem/simple_gpio/nrf_fem_config.h
+++ b/src/fem/simple_gpio/nrf_fem_config.h
@@ -107,6 +107,19 @@ typedef struct
 /** Default GPIOTE channel for FEM control. */
 #define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
 
+/** Mask of GPIO pins used for FEM control. */
+#define NRF_802154_FEM_PINS_USED_MASK              ((1 << NRF_FEM_CONTROL_DEFAULT_PA_PIN) | \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_LNA_PIN))
+
+/** Mask of PPI channels used for FEM control. */
+#define NRF_802154_FEM_PPI_CHANNELS_USED_MASK      ((1 << NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL) | \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL))
+
+/** Mask of GPIOTE channels used for FEM control. */
+#define NRF_802154_FEM_GPIOTE_CHANNELS_USED_MASK   (        \
+        (1 << NRF_FEM_CONTROL_DEAFULT_LNA_GPIOTE_CHANNEL) | \
+        (1 << NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fem/three_pin_gpio/nrf_fem_config.h
+++ b/src/fem/three_pin_gpio/nrf_fem_config.h
@@ -126,6 +126,22 @@ typedef struct
 /** Default GPIOTE channel for PA control. */
 #define NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL  7
 
+/** Mask of GPIO pins used for FEM control. */
+#define NRF_802154_FEM_PINS_USED_MASK              ((1 << NRF_FEM_CONTROL_DEFAULT_PA_PIN) |  \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_LNA_PIN) | \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_PDN_PIN))
+
+/** Mask of PPI channels used for FEM control. */
+#define NRF_802154_FEM_PPI_CHANNELS_USED_MASK      ((1 << NRF_FEM_CONTROL_DEFAULT_SET_PPI_CHANNEL) | \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_CLR_PPI_CHANNEL) | \
+                                                    (1 << NRF_FEM_CONTROL_DEFAULT_PDN_PPI_CHANNEL))
+
+/** Mask of GPIOTE channels used for FEM control. */
+#define NRF_802154_FEM_GPIOTE_CHANNELS_USED_MASK   (        \
+        (1 << NRF_FEM_CONTROL_DEFAULT_PDN_GPIOTE_CHANNEL) | \
+        (1 << NRF_FEM_CONTROL_DEFAULT_LNA_GPIOTE_CHANNEL) | \
+        (1 << NRF_FEM_CONTROL_DEFAULT_PA_GPIOTE_CHANNEL))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nrf_802154_config.h
+++ b/src/nrf_802154_config.h
@@ -125,71 +125,6 @@ extern "C" {
 #endif
 
 /**
- * @def NRF_802154_TIMER_INSTANCE
- *
- * The timer instance used both by the driver for ACK IFS and by the FEM module.
- *
- */
-#ifndef NRF_802154_TIMER_INSTANCE
-#define NRF_802154_TIMER_INSTANCE NRF_TIMER1
-#endif
-
-/**
- * @def NRF_802154_COUNTER_TIMER_INSTANCE
- *
- * The timer instance used by the driver for detecting when PSDU is being received.
- *
- * @note This configuration is used only when the NRF_RADIO_EVENT_BCMATCH event handling is disabled
- *       (see @ref NRF_802154_DISABLE_BCC_MATCHING).
- */
-#ifndef NRF_802154_COUNTER_TIMER_INSTANCE
-#define NRF_802154_COUNTER_TIMER_INSTANCE NRF_TIMER2
-#endif
-
-/**
- * @def NRF_802154_SWI_EGU_INSTANCE
- *
- * The SWI EGU instance used by the driver to synchronize PPIs and for requests and notifications if
- * SWI is in use.
- *
- * @note This option is used by the core module regardless of the driver configuration.
- *
- */
-#ifndef NRF_802154_SWI_EGU_INSTANCE
-
-#ifdef NRF52811_XXAA
-#define NRF_802154_SWI_EGU_INSTANCE NRF_EGU0
-#else
-#define NRF_802154_SWI_EGU_INSTANCE NRF_EGU3
-#endif
-
-#endif
-
-/**
- * @def NRF_802154_SWI_IRQ_HANDLER
- *
- * The SWI EGU IRQ handler used by the driver for requests and notifications if SWI is in use.
- *
- * @note This option is used when the driver uses SWI to process requests and notifications.
- *
- */
-#ifndef NRF_802154_SWI_IRQ_HANDLER
-#define NRF_802154_SWI_IRQ_HANDLER SWI3_EGU3_IRQHandler
-#endif
-
-/**
- * @def NRF_802154_SWI_IRQN
- *
- * The SWI EGU IRQ number used by the driver for requests and notifications if SWI is in use.
- *
- * @note This option is used when the driver uses SWI to process requests and notifications.
- *
- */
-#ifndef NRF_802154_SWI_IRQN
-#define NRF_802154_SWI_IRQN SWI3_EGU3_IRQn
-#endif
-
-/**
  * @def NRF_802154_SWI_PRIORITY
  *
  * The priority of software interrupt used for requests and notifications.
@@ -270,7 +205,7 @@ extern "C" {
  * @def NRF_802154_FRAME_TIMESTAMP_ENABLED
  *
  * If timestamps are to be added to the frames received.
- * Enabling this feature enables the functions @ref nrf_802154_received_timsestamp_raw,
+ * Enabling this feature enables the functions @ref nrf_802154_received_timestamp_raw,
  * @ref nrf_802154_received_timestamp, @ref nrf_802154_transmitted_timestamp_raw, and
  * @ref nrf_802154_transmitted_timestamp, which add timestamps to the frames received.
  *
@@ -338,63 +273,6 @@ extern "C" {
  */
 #ifndef NRF_802154_RTC_IRQ_PRIORITY
 #define NRF_802154_RTC_IRQ_PRIORITY 6
-#endif
-
-/**
- * @def NRF_802154_RTC_INSTANCE
- *
- * The RTC instance used in the standalone timer driver implementation.
- *
- * @note This configuration is only applicable for the Low Power Timer Abstraction Layer
- *       implementation in nrf_802154_lp_timer_nodrv.c.
- *
- */
-#ifndef NRF_802154_RTC_INSTANCE
-
-#ifdef NRF52811_XXAA
-#define NRF_802154_RTC_INSTANCE NRF_RTC0
-#else
-#define NRF_802154_RTC_INSTANCE NRF_RTC2
-#endif
-
-#endif
-
-/**
- * @def NRF_802154_RTC_IRQ_HANDLER
- *
- * The RTC interrupt handler name used in the standalone timer driver implementation.
- *
- * @note This configuration is only applicable for Low Power Timer Abstraction Layer implementation
- *       in nrf_802154_lp_timer_nodrv.c.
- *
- */
-#ifndef NRF_802154_RTC_IRQ_HANDLER
-
-#ifdef NRF52811_XXAA
-#define NRF_802154_RTC_IRQ_HANDLER RTC0_IRQHandler
-#else
-#define NRF_802154_RTC_IRQ_HANDLER RTC2_IRQHandler
-#endif
-
-#endif
-
-/**
- * @def NRF_802154_RTC_IRQN
- *
- * The RTC Interrupt number used in the standalone timer driver implementation.
- *
- * @note This configuration is only applicable for the Low Power Timer Abstraction Layer implementation
- *       in nrf_802154_lp_timer_nodrv.c.
- *
- */
-#ifndef NRF_802154_RTC_IRQN
-
-#ifdef NRF52811_XXAA
-#define NRF_802154_RTC_IRQN RTC0_IRQn
-#else
-#define NRF_802154_RTC_IRQN RTC2_IRQn
-#endif
-
 #endif
 
 /**

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -47,6 +47,7 @@
 #include "nrf_802154_critical_section.h"
 #include "nrf_802154_debug.h"
 #include "nrf_802154_notification.h"
+#include "nrf_802154_peripherals.h"
 #include "nrf_802154_pib.h"
 #include "nrf_802154_procedures_duration.h"
 #include "nrf_802154_rssi.h"
@@ -73,27 +74,20 @@
 
 #define EGU_EVENT                  NRF_EGU_EVENT_TRIGGERED15
 #define EGU_TASK                   NRF_EGU_TASK_TRIGGER15
-#define PPI_CH0                    NRF_PPI_CHANNEL6
-#define PPI_CH1                    NRF_PPI_CHANNEL7
-#define PPI_CH2                    NRF_PPI_CHANNEL8
-#define PPI_CH3                    NRF_PPI_CHANNEL9
-#define PPI_CH4                    NRF_PPI_CHANNEL10
-#define PPI_CH5                    NRF_PPI_CHANNEL11
-#define PPI_CH6                    NRF_PPI_CHANNEL12
-#define PPI_CHGRP0                 NRF_PPI_CHANNEL_GROUP0 ///< PPI group used to disable self-disabling PPIs
-#define PPI_CHGRP0_DIS_TASK        NRF_PPI_TASK_CHG0_DIS  ///< PPI task used to disable self-disabling PPIs
+#define PPI_CHGRP0                 NRF_802154_PPI_CORE_GROUP                     ///< PPI group used to disable self-disabling PPIs
+#define PPI_CHGRP0_DIS_TASK        NRF_PPI_TASK_CHG0_DIS                         ///< PPI task used to disable self-disabling PPIs
 
-#define PPI_DISABLED_EGU           PPI_CH0                ///< PPI that connects RADIO DISABLED event with EGU task
-#define PPI_EGU_RAMP_UP            PPI_CH1                ///< PPI that connects EGU event with RADIO TXEN or RXEN task
-#define PPI_EGU_TIMER_START        PPI_CH2                ///< PPI that connects EGU event with TIMER START task
-#define PPI_CRCERROR_CLEAR         PPI_CH3                ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
-#define PPI_CCAIDLE_FEM            PPI_CH3                ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
-#define PPI_TIMER_TX_ACK           PPI_CH3                ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
-#define PPI_CRCOK_DIS_PPI          PPI_CH4                ///< PPI that connects RADIO CRCOK event with task that disables PPI group
+#define PPI_DISABLED_EGU           NRF_802154_PPI_RADIO_DISABLED_TO_EGU          ///< PPI that connects RADIO DISABLED event with EGU task
+#define PPI_EGU_RAMP_UP            NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP           ///< PPI that connects EGU event with RADIO TXEN or RXEN task
+#define PPI_EGU_TIMER_START        NRF_802154_PPI_EGU_TO_TIMER_START             ///< PPI that connects EGU event with TIMER START task
+#define PPI_CRCERROR_CLEAR         NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR  ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#define PPI_CCAIDLE_FEM            NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE    ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
+#define PPI_TIMER_TX_ACK           NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN    ///< PPI that connects TIMER COMPARE event with RADIO TXEN task
+#define PPI_CRCOK_DIS_PPI          NRF_802154_PPI_RADIO_CRCOK_TO_PPI_GRP_DISABLE ///< PPI that connects RADIO CRCOK event with task that disables PPI group
 
 #if NRF_802154_DISABLE_BCC_MATCHING
-#define PPI_ADDRESS_COUNTER_COUNT  PPI_CH5                ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
-#define PPI_CRCERROR_COUNTER_CLEAR PPI_CH6                ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
+#define PPI_ADDRESS_COUNTER_COUNT  NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT    ///< PPI that connects RADIO ADDRESS event with TIMER COUNT task
+#define PPI_CRCERROR_COUNTER_CLEAR NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR   ///< PPI that connects RADIO CRCERROR event with TIMER CLEAR task
 #endif  // NRF_802154_DISABLE_BCC_MATCHING
 
 #if NRF_802154_DISABLE_BCC_MATCHING

--- a/src/nrf_802154_debug.c
+++ b/src/nrf_802154_debug.c
@@ -63,54 +63,54 @@ static void radio_event_gpio_toggle_init(void)
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_FRAMESTART);
     nrf_gpio_cfg_output(PIN_DBG_RADIO_EVT_EDEND);
 
-    nrf_gpiote_task_configure(0,
+    nrf_gpiote_task_configure(GPIOTE_DBG_RADIO_EVT_END,
                               PIN_DBG_RADIO_EVT_END,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(1,
+    nrf_gpiote_task_configure(GPIOTE_DBG_RADIO_EVT_DISABLED,
                               PIN_DBG_RADIO_EVT_DISABLED,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(2,
+    nrf_gpiote_task_configure(GPIOTE_DBG_RADIO_EVT_READY,
                               PIN_DBG_RADIO_EVT_READY,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(3,
+    nrf_gpiote_task_configure(GPIOTE_DBG_RADIO_EVT_FRAMESTART,
                               PIN_DBG_RADIO_EVT_FRAMESTART,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
-    nrf_gpiote_task_configure(4,
+    nrf_gpiote_task_configure(GPIOTE_DBG_RADIO_EVT_EDEND,
                               PIN_DBG_RADIO_EVT_EDEND,
                               NRF_GPIOTE_POLARITY_TOGGLE,
                               NRF_GPIOTE_INITIAL_VALUE_HIGH);
 
-    nrf_gpiote_task_enable(0);
-    nrf_gpiote_task_enable(1);
-    nrf_gpiote_task_enable(2);
-    nrf_gpiote_task_enable(3);
-    nrf_gpiote_task_enable(4);
+    nrf_gpiote_task_enable(GPIOTE_DBG_RADIO_EVT_END);
+    nrf_gpiote_task_enable(GPIOTE_DBG_RADIO_EVT_DISABLED);
+    nrf_gpiote_task_enable(GPIOTE_DBG_RADIO_EVT_READY);
+    nrf_gpiote_task_enable(GPIOTE_DBG_RADIO_EVT_FRAMESTART);
+    nrf_gpiote_task_enable(GPIOTE_DBG_RADIO_EVT_EDEND);
 
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0,
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_END,
                                    (uint32_t)&NRF_RADIO->EVENTS_END,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_0));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL1,
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_DISABLED,
                                    (uint32_t)&NRF_RADIO->EVENTS_DISABLED,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_1));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL2,
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_READY,
                                    (uint32_t)&NRF_RADIO->EVENTS_READY,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_2));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL3,
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_FRAMESTART,
                                    (uint32_t)&NRF_RADIO->EVENTS_FRAMESTART,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
-    nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL4,
+    nrf_ppi_channel_endpoint_setup((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_EDEND,
                                    (uint32_t)&NRF_RADIO->EVENTS_EDEND,
                                    nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_4));
 
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL0);
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL1);
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL2);
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL3);
-    nrf_ppi_channel_enable(NRF_PPI_CHANNEL4);
+    nrf_ppi_channel_enable((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_END);
+    nrf_ppi_channel_enable((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_DISABLED);
+    nrf_ppi_channel_enable((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_READY);
+    nrf_ppi_channel_enable((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_FRAMESTART);
+    nrf_ppi_channel_enable((nrf_ppi_channel_t)PPI_DBG_RADIO_EVT_EDEND);
 }
 
 /**

--- a/src/nrf_802154_debug.h
+++ b/src/nrf_802154_debug.h
@@ -141,6 +141,49 @@ extern "C" {
 
 #endif
 
+#define PPI_DBG_RADIO_EVT_END           0
+#define PPI_DBG_RADIO_EVT_DISABLED      1
+#define PPI_DBG_RADIO_EVT_READY         2
+#define PPI_DBG_RADIO_EVT_FRAMESTART    3
+#define PPI_DBG_RADIO_EVT_EDEND         4
+
+#define GPIOTE_DBG_RADIO_EVT_END        0
+#define GPIOTE_DBG_RADIO_EVT_DISABLED   1
+#define GPIOTE_DBG_RADIO_EVT_READY      2
+#define GPIOTE_DBG_RADIO_EVT_FRAMESTART 3
+#define GPIOTE_DBG_RADIO_EVT_EDEND      4
+
+#if ENABLE_DEBUG_GPIO
+
+#define NRF_802154_DEBUG_PINS_USED_MASK            ((1 << PIN_DBG_RADIO_EVT_END) |        \
+                                                    (1 << PIN_DBG_RADIO_EVT_DISABLED) |   \
+                                                    (1 << PIN_DBG_RADIO_EVT_READY) |      \
+                                                    (1 << PIN_DBG_RADIO_EVT_FRAMESTART) | \
+                                                    (1 << PIN_DBG_RADIO_EVT_EDEND) |      \
+                                                    (1 << PIN_DBG_RADIO_EVT_PHYEND))
+
+#define NRF_802154_DEBUG_PPI_CHANNELS_USED_MASK    ((1 << PPI_DBG_RADIO_EVT_END) |        \
+                                                    (1 << PPI_DBG_RADIO_EVT_DISABLED) |   \
+                                                    (1 << PPI_DBG_RADIO_EVT_READY) |      \
+                                                    (1 << PPI_DBG_RADIO_EVT_FRAMESTART) | \
+                                                    (1 << PPI_DBG_RADIO_EVT_EDEND) |      \
+                                                    (1 << PPI_DBG_RADIO_EVT_PHYEND))
+
+#define NRF_802154_DEBUG_GPIOTE_CHANNELS_USED_MASK ((1 << GPIOTE_DBG_RADIO_EVT_END) |        \
+                                                    (1 << GPIOTE_DBG_RADIO_EVT_DISABLED) |   \
+                                                    (1 << GPIOTE_DBG_RADIO_EVT_READY) |      \
+                                                    (1 << GPIOTE_DBG_RADIO_EVT_FRAMESTART) | \
+                                                    (1 << GPIOTE_DBG_RADIO_EVT_EDEND) |      \
+                                                    (1 << GPIOTE_DBG_RADIO_EVT_PHYEND))
+
+#else // ENABLE_DEBUG_GPIO
+
+#define NRF_802154_DEBUG_PINS_USED_MASK            0
+#define NRF_802154_DEBUG_PPI_CHANNELS_USED_MASK    0
+#define NRF_802154_DEBUG_GPIOTE_CHANNELS_USED_MASK 0
+
+#endif // ENABLE_DEBUG_GPIO
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nrf_802154_debug_core.h
+++ b/src/nrf_802154_debug_core.h
@@ -57,8 +57,24 @@ extern "C" {
 
 #define PIN_DBG_RTC0_EVT_REM            31
 
+#if ENABLE_DEBUG_GPIO
+
+#define NRF_802154_DEBUG_CORE_PINS_USED ((1 << PIN_DBG_TIMESLOT_ACTIVE) |       \
+                                         (1 << PIN_DBG_TIMESLOT_EXTEND_REQ) |   \
+                                         (1 << PIN_DBG_TIMESLOT_SESSION_IDLE) | \
+                                         (1 << PIN_DBG_TIMESLOT_RADIO_IRQ) |    \
+                                         (1 << PIN_DBG_TIMESLOT_FAILED) |       \
+                                         (1 << PIN_DBG_TIMESLOT_BLOCKED) |      \
+                                         (1 << PIN_DBG_RAAL_CRITICAL_SECTION))
+
+#else // ENABLE_DEBUG_GPIO
+
+#define NRF_802154_DEBUG_CORE_PINS_USED 0
+
+#endif
+
 #ifndef DEBUG_VERBOSITY
-#define DEBUG_VERBOSITY                 1
+#define DEBUG_VERBOSITY 1
 #endif
 
 #ifndef CU_TEST

--- a/src/nrf_802154_peripherals.h
+++ b/src/nrf_802154_peripherals.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief Module that defines peripherals usage by the 802.15.4 driver.
+ * @brief Module that defines the 802.15.4 driver peripheral usage.
  *
  */
 
@@ -330,7 +330,7 @@ extern "C" {
 /**
  * @def NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK
  *
- * Helper bit mask of PPI channels used by the 802.15.4 driver additionally when BCC matching
+ * Helper bit mask of PPI channels used additionally by the 802.15.4 driver when the BCC matching
  * is disabled.
  */
 #define NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK \

--- a/src/nrf_802154_peripherals.h
+++ b/src/nrf_802154_peripherals.h
@@ -1,0 +1,479 @@
+/* Copyright (c) 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @brief Module that defines peripherals usage by the 802.15.4 driver.
+ *
+ */
+
+#ifndef NRF_802154_PERIPHERALS_H__
+#define NRF_802154_PERIPHERALS_H__
+
+#include <nrf.h>
+#include <nrfx.h>
+#include "nrf_802154_config.h"
+#include "nrf_802154_debug.h"
+#include "nrf_802154_debug_core.h"
+#include "fem/nrf_fem_protocol_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @def NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+ *
+ * The timer instance used for precise frame timestamps and synchronous radio operations.
+ *
+ */
+#ifndef NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO
+#define NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO 0
+#endif
+#ifndef NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+#define NRF_802154_HIGH_PRECISION_TIMER_INSTANCE \
+    NRFX_CONCAT_2(NRF_TIMER, NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO)
+#endif // NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_TIMER_INSTANCE
+ *
+ * The timer instance used both by the driver for ACK IFS and by the FEM module.
+ *
+ */
+#ifndef NRF_802154_TIMER_INSTANCE_NO
+#define NRF_802154_TIMER_INSTANCE_NO 1
+#endif
+#ifndef NRF_802154_TIMER_INSTANCE
+#define NRF_802154_TIMER_INSTANCE \
+    NRFX_CONCAT_2(NRF_TIMER, NRF_802154_TIMER_INSTANCE_NO)
+#endif // NRF_802154_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_COUNTER_TIMER_INSTANCE
+ *
+ * The timer instance used by the driver for detecting when PSDU is being received.
+ *
+ * @note This configuration is used only when the NRF_RADIO_EVENT_BCMATCH event handling is disabled
+ *       (see @ref NRF_802154_DISABLE_BCC_MATCHING).
+ */
+#ifndef NRF_802154_COUNTER_TIMER_INSTANCE_NO
+#define NRF_802154_COUNTER_TIMER_INSTANCE_NO 2
+#endif
+#ifndef NRF_802154_COUNTER_TIMER_INSTANCE
+#define NRF_802154_COUNTER_TIMER_INSTANCE \
+    NRFX_CONCAT_2(NRF_TIMER, NRF_802154_COUNTER_TIMER_INSTANCE_NO)
+#endif // NRF_802154_COUNTER_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_SWI_EGU_INSTANCE
+ *
+ * The SWI EGU instance used by the driver to synchronize PPIs and for requests and notifications if
+ * SWI is in use.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_SWI_EGU_INSTANCE_NO
+
+#ifdef NRF52811_XXAA
+#define NRF_802154_SWI_EGU_INSTANCE_NO 0
+#else
+#define NRF_802154_SWI_EGU_INSTANCE_NO 3
+#endif
+
+#endif // NRF_802154_SWI_EGU_INSTANCE_NO
+
+#ifndef NRF_802154_SWI_EGU_INSTANCE
+#define NRF_802154_SWI_EGU_INSTANCE NRFX_CONCAT_2(NRF_EGU, NRF_802154_SWI_EGU_INSTANCE_NO)
+#endif
+
+/**
+ * @def NRF_802154_SWI_IRQ_HANDLER
+ *
+ * The SWI EGU IRQ handler used by the driver for requests and notifications if SWI is in use.
+ *
+ * @note This option is used when the driver uses SWI to process requests and notifications.
+ *
+ */
+#ifndef NRF_802154_SWI_IRQ_HANDLER
+#define NRF_802154_SWI_IRQ_HANDLER                                          \
+    NRFX_CONCAT_3(NRFX_CONCAT_3(SWI, NRF_802154_SWI_EGU_INSTANCE_NO, _EGU), \
+                  NRF_802154_SWI_EGU_INSTANCE_NO,                           \
+                  _IRQHandler)
+#endif // NRF_802154_SWI_IRQ_HANDLER
+
+/**
+ * @def NRF_802154_SWI_IRQN
+ *
+ * The SWI EGU IRQ number used by the driver for requests and notifications if SWI is in use.
+ *
+ * @note This option is used when the driver uses SWI to process requests and notifications.
+ *
+ */
+#ifndef NRF_802154_SWI_IRQN
+#define NRF_802154_SWI_IRQN                                                 \
+    NRFX_CONCAT_3(NRFX_CONCAT_3(SWI, NRF_802154_SWI_EGU_INSTANCE_NO, _EGU), \
+                  NRF_802154_SWI_EGU_INSTANCE_NO,                           \
+                  _IRQn)
+#endif // NRF_802154_SWI_IRQN
+
+/**
+ * @def NRF_802154_RTC_INSTANCE
+ *
+ * The RTC instance used in the standalone timer driver implementation.
+ *
+ * @note This configuration is only applicable for the Low Power Timer Abstraction Layer
+ *       implementation in nrf_802154_lp_timer_nodrv.c.
+ *
+ */
+#ifndef NRF_802154_RTC_INSTANCE_NO
+
+#ifdef NRF52811_XXAA
+#define NRF_802154_RTC_INSTANCE_NO 0
+#else
+#define NRF_802154_RTC_INSTANCE_NO 2
+#endif
+
+#endif // NRF_802154_RTC_INSTANCE_NO
+
+#ifndef NRF_802154_RTC_INSTANCE
+#define NRF_802154_RTC_INSTANCE NRFX_CONCAT_2(NRF_RTC, NRF_802154_RTC_INSTANCE_NO)
+#endif
+
+/**
+ * @def NRF_802154_RTC_IRQ_HANDLER
+ *
+ * The RTC interrupt handler name used in the standalone timer driver implementation.
+ *
+ * @note This configuration is only applicable for Low Power Timer Abstraction Layer implementation
+ *       in nrf_802154_lp_timer_nodrv.c.
+ *
+ */
+#ifndef NRF_802154_RTC_IRQ_HANDLER
+#define NRF_802154_RTC_IRQ_HANDLER NRFX_CONCAT_3(RTC, NRF_802154_RTC_INSTANCE_NO, _IRQHandler)
+#endif
+
+/**
+ * @def NRF_802154_RTC_IRQN
+ *
+ * The RTC Interrupt number used in the standalone timer driver implementation.
+ *
+ * @note This configuration is only applicable for the Low Power Timer Abstraction Layer implementation
+ *       in nrf_802154_lp_timer_nodrv.c.
+ *
+ */
+#ifndef NRF_802154_RTC_IRQN
+#define NRF_802154_RTC_IRQN NRFX_CONCAT_3(RTC, NRF_802154_RTC_INSTANCE_NO, _IRQn)
+#endif
+
+/**
+ * @def NRF_802154_PPI_RADIO_DISABLED_TO_EGU
+ *
+ * The PPI channel that connects RADIO_DISABLED event to EGU task.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_DISABLED_TO_EGU
+#define NRF_802154_PPI_RADIO_DISABLED_TO_EGU NRF_PPI_CHANNEL6
+#endif
+
+/**
+ * @def NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP
+ *
+ * The PPI channel that connects EGU event to RADIO_TXEN or RADIO_RXEN task.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP
+#define NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP NRF_PPI_CHANNEL7
+#endif
+
+/**
+ * @def NRF_802154_PPI_EGU_TO_TIMER_START
+ *
+ * The PPI channel that connects EGU event to TIMER_START task.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_PPI_EGU_TO_TIMER_START
+#define NRF_802154_PPI_EGU_TO_TIMER_START NRF_PPI_CHANNEL8
+#endif
+
+/**
+ * @def NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
+ *
+ * The PPI channel that connects RADIO_CRCERROR event to TIMER_CLEAR task.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
+ *       and @ref NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN.
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
+#define NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR NRF_PPI_CHANNEL9
+#endif
+
+/**
+ * @def NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
+ *
+ * The PPI channel that connects RADIO_CCAIDLE event to the GPIOTE tasks used by the Frontend.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
+ *       and @ref NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN.
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
+#define NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE NRF_PPI_CHANNEL9
+#endif
+
+/**
+ * @def NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN
+ *
+ * The PPI channel that connects TIMER_COMPARE event to RADIO_TXEN task.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
+ *       and @ref NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE.
+ *
+ */
+#ifndef NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN
+#define NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN NRF_PPI_CHANNEL9
+#endif
+
+/**
+ * @def NRF_802154_PPI_RADIO_CRCOK_TO_PPI_GRP_DISABLE
+ *
+ * The PPI channel that connects RADIO_CRCOK event with the task that disables the whole PPI group.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_CRCOK_TO_PPI_GRP_DISABLE
+#define NRF_802154_PPI_RADIO_CRCOK_TO_PPI_GRP_DISABLE NRF_PPI_CHANNEL10
+#endif
+
+#ifdef NRF_802154_DISABLE_BCC_MATCHING
+
+/**
+ * @def NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT
+ *
+ * The PPI channel that connects RADIO_ADDRESS event to TIMER_COUNT task.
+ *
+ * @note This configuration is used only when the NRF_RADIO_EVENT_BCMATCH event handling is disabled
+ *       (see @ref NRF_802154_DISABLE_BCC_MATCHING).
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT
+#define NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT NRF_PPI_CHANNEL11
+#endif
+
+/**
+ * @def NRF_802154_PPI_RADIO_CRCERROR_TO_COUNTER_CLEAR
+ *
+ * The PPI channel that connects RADIO_CRCERROR event to TIMER_CLEAR task.
+ *
+ * @note This option is used only when the NRF_RADIO_EVENT_BCMATCH event handling is disabled
+ *       (see @ref NRF_802154_DISABLE_BCC_MATCHING).
+ *
+ */
+#ifndef NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR
+#define NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR NRF_PPI_CHANNEL12
+#endif
+
+#define NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK \
+    ((1 << NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT) |       \
+     (1 << NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR))
+
+#else // NRF_802154_DISABLE_BCC_MATCHING
+
+#define NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK 0
+
+#endif // NRF_802154_DISABLE_BCC_MATCHING
+
+#ifdef NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+/**
+ * @def NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE
+ *
+ * The PPI channel that connects LP timer's COMPARE event to HP timer's TIMER_CAPTURE task.
+ *
+ * @note This option is used only when the timestamping feature is enabled
+ *       (see @ref NRF_802154_FRAME_TIMESTAMP_ENABLED).
+ *
+ */
+#ifndef NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE
+#define NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE NRF_PPI_CHANNEL13
+#endif
+
+/**
+ * @def NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE
+ *
+ * The PPI channel that connects provided event to HP timer's TIMER_CAPTURE task.
+ *
+ * @note This option is used only when the timestamping feature is enabled
+ *       (see @ref NRF_802154_FRAME_TIMESTAMP_ENABLED).
+ *
+ */
+#ifndef NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE
+#define NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE NRF_PPI_CHANNEL14
+#endif
+
+#define NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK     ( \
+        (NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE) |   \
+        (NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE))
+
+#else // NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+#define NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK 0
+
+#endif // NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+/**
+ * @def NRF_802154_PPI_CORE_GROUP
+ *
+ * The PPI channel group used to disable self-disabling PPIs used by the core module.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_PPI_CORE_GROUP
+#define NRF_802154_PPI_CORE_GROUP NRF_PPI_CHANNEL_GROUP0
+#endif
+
+#ifdef NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+/**
+ * @def NRF_802154_PPI_TIMESTAMP_GROUP
+ *
+ * The PPI channel group used to control PPIs used for timestamping.
+ *
+ * @note This option is used only when the timestamping feature is enabled
+ *       (see @ref NRF_802154_FRAME_TIMESTAMP_ENABLED).
+ *
+ */
+#ifndef NRF_802154_PPI_TIMESTAMP_GROUP
+#define NRF_802154_PPI_TIMESTAMP_GROUP NRF_PPI_CHANNEL_GROUP1
+#endif
+
+#endif // NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+/**
+ * @def NRF_802154_TIMERS_USED_MASK
+ *
+ * Bit mask of instances of timer peripherals used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_TIMERS_USED_MASK
+#define NRF_802154_TIMERS_USED_MASK ((1 << NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO) | \
+                                     (1 << NRF_802154_TIMER_INSTANCE_NO) |                \
+                                     (1 << NRF_802154_COUNTER_TIMER_INSTANCE_NO))
+#endif // NRF_802154_TIMERS_USED_MASK
+
+/**
+ * @def NRF_802154_SWI_EGU_USED_MASK
+ *
+ * Bit mask of instances of SWI/EGU peripherals used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_SWI_EGU_USED_MASK
+#define NRF_802154_SWI_EGU_USED_MASK (1 << NRF_802154_SWI_EGU_INSTANCE_NO)
+#endif
+
+/**
+ * @def NRF_802154_RTC_USED_MASK
+ *
+ * Bit mask of instances of RTC peripherals used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_RTC_USED_MASK
+#define NRF_802154_RTC_USED_MASK (1 << NRF_802154_RTC_INSTANCE_NO)
+#endif
+
+/**
+ * @def NRF_802154_GPIO_PINS_USED_MASK
+ *
+ * Bit mask of GPIO pins used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_GPIO_PINS_USED_MASK
+#define NRF_802154_GPIO_PINS_USED_MASK (NRF_802154_FEM_PINS_USED_MASK | \
+                                        NRF_802154_DEBUG_PINS_USED_MASK)
+#endif // NRF_802154_GPIO_PINS_USED_MASK
+
+/**
+ * @def NRF_802154_GPIOTE_CHANNELS_USED_MASK
+ *
+ * Bit mask of GPIOTE peripherals used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_GPIOTE_CHANNELS_USED_MASK
+#define NRF_802154_GPIOTE_CHANNELS_USED_MASK (NRF_802154_FEM_GPIOTE_CHANNELS_USED_MASK | \
+                                              NRF_802154_DEBUG_GPIOTE_CHANNELS_USED_MASK)
+#endif // NRF_802154_GPIOTE_CHANNELS_USED_MASK
+
+/**
+ * @def NRF_80254_PPI_CHANNELS_USED_MASK
+ *
+ * Bit mask of PPI channels used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_PPI_CHANNELS_USED_MASK
+#define NRF_802154_PPI_CHANNELS_USED_MASK ((1 << NRF_802154_PPI_RADIO_DISABLED_TO_EGU) |            \
+                                           (1 << NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP) |             \
+                                           (1 << NRF_802154_PPI_EGU_TO_TIMER_START) |               \
+                                           (1 << NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR) |    \
+                                           (1 << NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE) |      \
+                                           (1 << NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN) |      \
+                                           (1 << NRF_802154_PPI_RADIO_CRCOK_TO_PPI_GRP_DISABLE) |   \
+                                           NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK | \
+                                           NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK |            \
+                                           NRF_802154_FEM_PPI_CHANNELS_USED_MASK |                  \
+                                           NRF_802154_DEBUG_PPI_CHANNELS_USED_MASK)
+#endif // NRF_802154_PPI_CHANNELS_USED_MASK
+
+/**
+ * @def NRF_802154_PPI_GROUPS_USED_MASK
+ *
+ * Bit mask of PPI groups identifiers used by the 802.15.4 driver.
+ */
+#ifndef NRF_802154_PPI_GROUPS_USED_MASK
+
+#ifdef NRF_802154_FRAME_TIMESTAMP_ENABLED
+#define NRF_802154_PPI_GROUPS_USED_MASK ((1 << NRF_802154_PPI_CORE_GROUP) | \
+                                         (1 << NRF_802154_PPI_TIMESTAMP_GROUP)
+#else // NRF_802154_FRAME_TIMESTAMP_ENABLED
+#define NRF_802154_PPI_GROUPS_USED_MASK (1 << NRF_802154_PPI_CORE_GROUP)
+#endif  // NRF_802154_FRAME_TIMESTAMP_ENABLED
+
+#endif // NRF_802154_PPI_GROUPS_USED_MASK
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRF_802154_PERIPHERALS_H__

--- a/src/nrf_802154_peripherals.h
+++ b/src/nrf_802154_peripherals.h
@@ -48,18 +48,33 @@ extern "C" {
 #endif
 
 /**
- * @def NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+ * @def NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO
  *
- * The timer instance used for precise frame timestamps and synchronous radio operations.
+ * Number of the timer instance used for precise frame timestamps and synchronous radio operations.
  *
  */
 #ifndef NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO
 #define NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO 0
 #endif
-#ifndef NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+ *
+ * The timer instance used for precise frame timestamps and synchronous radio operations.
+ *
+ */
 #define NRF_802154_HIGH_PRECISION_TIMER_INSTANCE \
     NRFX_CONCAT_2(NRF_TIMER, NRF_802154_HIGH_PRECISION_TIMER_INSTANCE_NO)
-#endif // NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_TIMER_INSTANCE_NO
+ *
+ * Number of the timer instance used both by the driver for ACK IFS and by the FEM module.
+ *
+ */
+#ifndef NRF_802154_TIMER_INSTANCE_NO
+#define NRF_802154_TIMER_INSTANCE_NO 1
+#endif
 
 /**
  * @def NRF_802154_TIMER_INSTANCE
@@ -67,13 +82,18 @@ extern "C" {
  * The timer instance used both by the driver for ACK IFS and by the FEM module.
  *
  */
-#ifndef NRF_802154_TIMER_INSTANCE_NO
-#define NRF_802154_TIMER_INSTANCE_NO 1
-#endif
-#ifndef NRF_802154_TIMER_INSTANCE
 #define NRF_802154_TIMER_INSTANCE \
     NRFX_CONCAT_2(NRF_TIMER, NRF_802154_TIMER_INSTANCE_NO)
-#endif // NRF_802154_TIMER_INSTANCE
+
+/**
+ * @def NRF_802154_COUNTER_TIMER_INSTANCE_NO
+ *
+ * Number of the timer instance used for detecting when PSDU is being received.
+ *
+ */
+#ifndef NRF_802154_COUNTER_TIMER_INSTANCE_NO
+#define NRF_802154_COUNTER_TIMER_INSTANCE_NO 2
+#endif
 
 /**
  * @def NRF_802154_COUNTER_TIMER_INSTANCE
@@ -83,21 +103,14 @@ extern "C" {
  * @note This configuration is used only when the NRF_RADIO_EVENT_BCMATCH event handling is disabled
  *       (see @ref NRF_802154_DISABLE_BCC_MATCHING).
  */
-#ifndef NRF_802154_COUNTER_TIMER_INSTANCE_NO
-#define NRF_802154_COUNTER_TIMER_INSTANCE_NO 2
-#endif
-#ifndef NRF_802154_COUNTER_TIMER_INSTANCE
 #define NRF_802154_COUNTER_TIMER_INSTANCE \
     NRFX_CONCAT_2(NRF_TIMER, NRF_802154_COUNTER_TIMER_INSTANCE_NO)
-#endif // NRF_802154_COUNTER_TIMER_INSTANCE
 
 /**
- * @def NRF_802154_SWI_EGU_INSTANCE
+ * @def NRF_802154_SWI_EGU_INSTANCE_NO
  *
- * The SWI EGU instance used by the driver to synchronize PPIs and for requests and notifications if
- * SWI is in use.
- *
- * @note This option is used by the core module regardless of the driver configuration.
+ * Number of the SWI EGU instance used by the driver to synchronize PPIs and for requests and
+ * notifications if SWI is in use.
  *
  */
 #ifndef NRF_802154_SWI_EGU_INSTANCE_NO
@@ -110,9 +123,16 @@ extern "C" {
 
 #endif // NRF_802154_SWI_EGU_INSTANCE_NO
 
-#ifndef NRF_802154_SWI_EGU_INSTANCE
+/**
+ * @def NRF_802154_SWI_EGU_INSTANCE
+ *
+ * The SWI EGU instance used by the driver to synchronize PPIs and for requests and notifications if
+ * SWI is in use.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
 #define NRF_802154_SWI_EGU_INSTANCE NRFX_CONCAT_2(NRF_EGU, NRF_802154_SWI_EGU_INSTANCE_NO)
-#endif
 
 /**
  * @def NRF_802154_SWI_IRQ_HANDLER
@@ -122,12 +142,10 @@ extern "C" {
  * @note This option is used when the driver uses SWI to process requests and notifications.
  *
  */
-#ifndef NRF_802154_SWI_IRQ_HANDLER
 #define NRF_802154_SWI_IRQ_HANDLER                                          \
     NRFX_CONCAT_3(NRFX_CONCAT_3(SWI, NRF_802154_SWI_EGU_INSTANCE_NO, _EGU), \
                   NRF_802154_SWI_EGU_INSTANCE_NO,                           \
                   _IRQHandler)
-#endif // NRF_802154_SWI_IRQ_HANDLER
 
 /**
  * @def NRF_802154_SWI_IRQN
@@ -137,20 +155,15 @@ extern "C" {
  * @note This option is used when the driver uses SWI to process requests and notifications.
  *
  */
-#ifndef NRF_802154_SWI_IRQN
 #define NRF_802154_SWI_IRQN                                                 \
     NRFX_CONCAT_3(NRFX_CONCAT_3(SWI, NRF_802154_SWI_EGU_INSTANCE_NO, _EGU), \
                   NRF_802154_SWI_EGU_INSTANCE_NO,                           \
                   _IRQn)
-#endif // NRF_802154_SWI_IRQN
 
 /**
- * @def NRF_802154_RTC_INSTANCE
+ * @def NRF_802154_RTC_INSTANCE_NO
  *
- * The RTC instance used in the standalone timer driver implementation.
- *
- * @note This configuration is only applicable for the Low Power Timer Abstraction Layer
- *       implementation in nrf_802154_lp_timer_nodrv.c.
+ * Number of the RTC instance used in the standalone timer driver implementation.
  *
  */
 #ifndef NRF_802154_RTC_INSTANCE_NO
@@ -163,9 +176,16 @@ extern "C" {
 
 #endif // NRF_802154_RTC_INSTANCE_NO
 
-#ifndef NRF_802154_RTC_INSTANCE
-#define NRF_802154_RTC_INSTANCE NRFX_CONCAT_2(NRF_RTC, NRF_802154_RTC_INSTANCE_NO)
-#endif
+/**
+ * @def NRF_802154_RTC_INSTANCE
+ *
+ * The RTC instance used in the standalone timer driver implementation.
+ *
+ * @note This configuration is only applicable for the Low Power Timer Abstraction Layer
+ *       implementation in nrf_802154_lp_timer_nodrv.c.
+ *
+ */
+#define NRF_802154_RTC_INSTANCE    NRFX_CONCAT_2(NRF_RTC, NRF_802154_RTC_INSTANCE_NO)
 
 /**
  * @def NRF_802154_RTC_IRQ_HANDLER
@@ -176,9 +196,7 @@ extern "C" {
  *       in nrf_802154_lp_timer_nodrv.c.
  *
  */
-#ifndef NRF_802154_RTC_IRQ_HANDLER
 #define NRF_802154_RTC_IRQ_HANDLER NRFX_CONCAT_3(RTC, NRF_802154_RTC_INSTANCE_NO, _IRQHandler)
-#endif
 
 /**
  * @def NRF_802154_RTC_IRQN
@@ -189,9 +207,7 @@ extern "C" {
  *       in nrf_802154_lp_timer_nodrv.c.
  *
  */
-#ifndef NRF_802154_RTC_IRQN
-#define NRF_802154_RTC_IRQN NRFX_CONCAT_3(RTC, NRF_802154_RTC_INSTANCE_NO, _IRQn)
-#endif
+#define NRF_802154_RTC_IRQN        NRFX_CONCAT_3(RTC, NRF_802154_RTC_INSTANCE_NO, _IRQn)
 
 /**
  * @def NRF_802154_PPI_RADIO_DISABLED_TO_EGU
@@ -311,6 +327,12 @@ extern "C" {
 #define NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR NRF_PPI_CHANNEL12
 #endif
 
+/**
+ * @def NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK
+ *
+ * Helper bit mask of PPI channels used by the 802.15.4 driver additionally when BCC matching
+ * is disabled.
+ */
 #define NRF_802154_DISABLE_BCC_MATCHING_PPI_CHANNELS_USED_MASK \
     ((1 << NRF_802154_PPI_RADIO_ADDR_TO_COUNTER_COUNT) |       \
      (1 << NRF_802154_PPI_RADIO_CRCERROR_COUNTER_CLEAR))
@@ -349,9 +371,14 @@ extern "C" {
 #define NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE NRF_PPI_CHANNEL14
 #endif
 
-#define NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK     ( \
-        (NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE) |   \
-        (NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE))
+/**
+ * @def NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK
+ *
+ * Helper bit mask of PPI channels used by the 802.15.4 driver for timestamping.
+ */
+#define NRF_802154_TIMESTAMP_PPI_CHANNELS_USED_MASK       \
+    ((1 << NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE) | \
+     (1 << NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE))
 
 #else // NRF_802154_FRAME_TIMESTAMP_ENABLED
 

--- a/src/nrf_802154_request_swi.c
+++ b/src/nrf_802154_request_swi.c
@@ -44,9 +44,10 @@
 #include "nrf_802154_core.h"
 #include "nrf_802154_critical_section.h"
 #include "nrf_802154_debug.h"
-#include "nrf_802154_utils.h"
+#include "nrf_802154_peripherals.h"
 #include "nrf_802154_rx_buffer.h"
 #include "nrf_802154_swi.h"
+#include "nrf_802154_utils.h"
 #include "nrf_radio.h"
 
 #include <nrf.h>

--- a/src/nrf_802154_swi.c
+++ b/src/nrf_802154_swi.c
@@ -43,6 +43,7 @@
 #include "nrf_802154.h"
 #include "nrf_802154_config.h"
 #include "nrf_802154_core.h"
+#include "nrf_802154_peripherals.h"
 #include "nrf_802154_rx_buffer.h"
 #include "nrf_802154_utils.h"
 #include "nrf_egu.h"
@@ -54,6 +55,7 @@
  * detection.
  */
 #define NTF_QUEUE_SIZE     (NRF_802154_RX_BUFFERS + 3)
+
 /** Size of requests queue.
  *
  * Two is minimal queue size. It is not expected in current implementation to queue a few requests.

--- a/src/nrf_802154_timer_coord.c
+++ b/src/nrf_802154_timer_coord.c
@@ -42,7 +42,7 @@
 
 #include "nrf_802154_config.h"
 #include "nrf_802154_debug.h"
-#include "nrf_ppi.h"
+#include "nrf_802154_peripherals.h"
 #include "platform/hp_timer/nrf_802154_hp_timer.h"
 #include "platform/lp_timer/nrf_802154_lp_timer.h"
 
@@ -57,13 +57,9 @@
 #define RESYNC_TIME              (4 * TIME_BASE) ///< Delay of following resynchronizations.
 #define EWMA_COEF                (8)             ///< Weight used in the EWMA algorithm.
 
-#define PPI_CH0                  NRF_PPI_CHANNEL13
-#define PPI_CH1                  NRF_PPI_CHANNEL14
-#define PPI_CHGRP0               NRF_PPI_CHANNEL_GROUP1
-
-#define PPI_SYNC                 PPI_CH0
-#define PPI_TIMESTAMP            PPI_CH1
-#define PPI_TIMESTAMP_GROUP      PPI_CHGRP0
+#define PPI_SYNC                 NRF_802154_PPI_RTC_COMPARE_TO_TIMER_CAPTURE
+#define PPI_TIMESTAMP            NRF_802154_PPI_TIMESTAMP_EVENT_TO_TIMER_CAPTURE
+#define PPI_TIMESTAMP_GROUP      NRF_802154_PPI_TIMESTAMP_GROUP
 
 #if NRF_802154_FRAME_TIMESTAMP_ENABLED
 // Structure holding common timepoint from both timers.

--- a/src/platform/hp_timer/nrf_802154_hp_timer.c
+++ b/src/platform/hp_timer/nrf_802154_hp_timer.c
@@ -47,9 +47,10 @@
 #include <nrf_timer.h>
 
 #include "nrf_802154_config.h"
+#include "nrf_802154_peripherals.h"
 
 /**@brief Timer instance. */
-#define TIMER                 NRF_TIMER0
+#define TIMER                 NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
 
 /**@brief Timer compare channel definitions. */
 #define TIMER_CC_CAPTURE      NRF_TIMER_CC_CHANNEL1

--- a/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
+++ b/src/platform/lp_timer/nrf_802154_lp_timer_nodrv.c
@@ -45,6 +45,7 @@
 
 #include "platform/clock/nrf_802154_clock.h"
 #include "nrf_802154_config.h"
+#include "nrf_802154_peripherals.h"
 #include "nrf_802154_utils.h"
 
 #define RTC_LP_TIMER_COMPARE_CHANNEL    0


### PR DESCRIPTION
This PR moves all information about peripherals used by the driver to a separate file.