### PR TITLE
Reduce timeslot request timeout to improve switching time

### DIFF
--- a/src/rsch/raal/softdevice/nrf_raal_softdevice.h
+++ b/src/rsch/raal/softdevice/nrf_raal_softdevice.h
@@ -51,7 +51,7 @@ extern "C" {
 #define NRF_RAAL_TIMESLOT_DEFAULT_ALLOC_ITERS               5
 #define NRF_RAAL_TIMESLOT_DEFAULT_SAFE_MARGIN               nrf_raal_softdevice_safe_margin_calc( \
         NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM)
-#define NRF_RAAL_TIMESLOT_DEFAULT_TIMEOUT                   4500
+#define NRF_RAAL_TIMESLOT_DEFAULT_TIMEOUT                   2500
 #define NRF_RAAL_TIMESLOT_DEFAULT_MAX_LENGTH                120000000
 #define NRF_RAAL_DEFAULT_LF_CLK_ACCURACY_PPM                500
 


### PR DESCRIPTION
SoftDevice 7 improves switching time performance. In order to utilize
improved switching time, the timeout shall be reduced at the cost of
much more BLOCKED events reported by SoftDevice Timeslot API.

Reducing number of BLOCKET events may be in a scope of futher
optimization.