### PR TITLE
Pr/clean up trx module

### DIFF
--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -233,14 +233,6 @@ void nrf_802154_deinit(void)
     nrf_802154_core_deinit();
 }
 
-#if !NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
-void nrf_802154_radio_irq_handler(void)
-{
-    nrf_802154_core_irq_handler();
-}
-
-#endif // !NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
-
 #if ENABLE_FEM
 void nrf_802154_fem_control_cfg_set(nrf_802154_fem_control_cfg_t const * const p_cfg)
 {

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1075,7 +1075,7 @@ uint8_t nrf_802154_trx_receive_on_bcmatch(uint8_t bcc)
         else if ((filter_result == NRF_802154_RX_ERROR_INVALID_LENGTH) ||
                  (!nrf_802154_pib_promiscuous_get()))
         {
-            nrf_802154_trx_receive_frame_abort();
+            nrf_802154_trx_abort();
             rx_init(true);
 
             frame_accepted = false;
@@ -1105,7 +1105,7 @@ uint8_t nrf_802154_trx_receive_on_bcmatch(uint8_t bcc)
         else
         {
             // Disable receiver and wait for a new timeslot.
-            nrf_802154_trx_receive_frame_abort();
+            nrf_802154_trx_abort();
 
             // We should not leave trx in temporary state, let's receive then.
             // We avoid hard reset of radio during TX ACK phase due to timeslot end,

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -725,9 +725,6 @@ static void rx_init(bool disabled_was_triggered)
 
     nrf_802154_trx_receive_frame(BCC_INIT / 8U);
 
-    // TODO: This is UGLY looking into radio's internal, should be wrapped by trx.
-    // TODO: This is done also after triggering receive. There is possibility that frame will be received before
-    // we connect event crcok to timer coord
     // Configure the timer coordinator to get a timestamp of the CRCOK event.
     nrf_802154_timer_coord_timestamp_prepare(
         (uint32_t)nrf_radio_event_address_get(NRF_RADIO_EVENT_CRCOK));
@@ -912,7 +909,6 @@ static void on_preconditions_denied(radio_state_t state)
         case RADIO_STATE_RX:
             if (receiving_psdu_now)
             {
-                // TODO: Add new status code
                 receive_failed_notify(NRF_802154_RX_ERROR_ABORTED);
             }
 
@@ -1072,7 +1068,7 @@ uint8_t nrf_802154_trx_receive_on_bcmatch(uint8_t bcc)
             else
             {
                 m_flags.frame_filtered = true;
-                // TODO request higher preconditions (RX active)
+
                 nrf_802154_rsch_crit_sect_prio_request(RSCH_PRIO_RX);
             }
         }
@@ -1452,7 +1448,6 @@ static bool ack_match_check_version_2(const uint8_t * p_tx_data, const uint8_t *
     assert(parse_result);
     parse_result = nrf_802154_frame_parser_mhr_parse(p_ack_data, &ack_mhr_data);
 
-    // TOOD: Check PHR (frame length), may be complicated
     if (!parse_result ||
         (tx_mhr_data.p_src_addr == NULL) ||
         (ack_mhr_data.p_dst_addr == NULL) ||
@@ -1865,7 +1860,6 @@ bool nrf_802154_core_cca_cfg_update(void)
     {
         if (timeslot_is_granted())
         {
-            // TODO: rewrite this function to use trx
             nrf_802154_trx_cca_configuration_update();
         }
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1178,7 +1178,7 @@ void nrf_802154_trx_receive_frame_received(void)
     {
         // Frame is destined to this node but there is no timeslot to transmit ACK.
         // Just disable receiver and wait for a new timeslot.
-        nrf_802154_trx_receive_frame_abort();
+        nrf_802154_trx_abort();
 
         rx_flags_clear();
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -139,9 +139,6 @@ static void state_set(radio_state_t state)
 
     nrf_802154_log(EVENT_SET_STATE, (uint32_t)state);
 
-    /* We should request preconditions according to desired state, currently we
-     * request preconditions only for non-sleep and drop preconditions for sleep */
-
     request_preconditions_for_state(state);
 }
 
@@ -1123,6 +1120,8 @@ static void on_bad_ack(void);
 
 void nrf_802154_trx_receive_frame_crcerror(void)
 {
+    assert(m_state == RADIO_STATE_RX);
+
     // We don't change receive buffer, receive will go to the same that was already used
 #if !NRF_802154_DISABLE_BCC_MATCHING
     request_preconditions_for_state(m_state);
@@ -1450,7 +1449,6 @@ void nrf_802154_trx_receive_ack_received(void)
         transmitted_frame_notify(p_ack_buffer->data,           // phr + psdu
                                  rssi_last_measurement_get(),  // rssi
                                  lqi_get(p_ack_buffer->data)); // lqi;
-
     }
     else
     {
@@ -1493,8 +1491,7 @@ void nrf_802154_trx_energy_detection_finished(uint8_t ed_sample)
         else
         {
             /* There is too little time in current timeslot, just wait for timeslot end.
-             * Operation will be resumed in next timeslot
-             */
+             * Operation will be resumed in next timeslot */
         }
     }
     else

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -2047,4 +2047,4 @@ void RADIO_IRQHandler(void)
     nrf_802154_radio_irq_handler();
 }
 
-#endif  // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
+#endif // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -165,26 +165,22 @@ static const nrf_802154_fal_event_t m_deactivate_on_disable =
 
 static const nrf_802154_fal_event_t m_activate_rx_cc0 =
 {
-    .type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
-    .override_ppi                 = false,
-    .event.timer.p_timer_instance =
-        NRF_802154_TIMER_INSTANCE,
+    .type                             = NRF_802154_FAL_EVENT_TYPE_TIMER,
+    .override_ppi                     = false,
+    .event.timer.p_timer_instance     = NRF_802154_TIMER_INSTANCE,
     .event.timer.compare_channel_mask =
         ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
-    .event.timer.counter_value =
-        RX_RAMP_UP_TIME
+    .event.timer.counter_value = RX_RAMP_UP_TIME
 };
 
 static const nrf_802154_fal_event_t m_activate_tx_cc0 =
 {
-    .type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
-    .override_ppi                 = false,
-    .event.timer.p_timer_instance =
-        NRF_802154_TIMER_INSTANCE,
+    .type                             = NRF_802154_FAL_EVENT_TYPE_TIMER,
+    .override_ppi                     = false,
+    .event.timer.p_timer_instance     = NRF_802154_TIMER_INSTANCE,
     .event.timer.compare_channel_mask =
         ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
-    .event.timer.counter_value =
-        TX_RAMP_UP_TIME
+    .event.timer.counter_value = TX_RAMP_UP_TIME
 };
 
 static const nrf_802154_fal_event_t m_ccaidle =
@@ -192,8 +188,7 @@ static const nrf_802154_fal_event_t m_ccaidle =
     .type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
     .override_ppi                   = true,
     .ppi_ch_id                      = PPI_CCAIDLE_FEM,
-    .event.generic.register_address =
-        ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_CCAIDLE)
+    .event.generic.register_address = ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_CCAIDLE)
 };
 
 /**@brief Fal event used by @ref nrf_802154_trx_transmit_ack and @ref txack_finish */
@@ -224,14 +219,14 @@ static nrf_802154_flags_t m_flags; ///< Flags used to store the current driver s
 static volatile uint32_t m_timer_value_on_radio_end_event;
 static volatile bool     m_transmit_with_cca;
 
-static void nrf_802154_trx_go_idle_abort(void);
-static void nrf_802154_trx_receive_frame_abort(void);
-static void nrf_802154_trx_receive_ack_abort(void);
-static void nrf_802154_trx_transmit_frame_abort(void);
-static void nrf_802154_trx_transmit_ack_abort(void);
-static void nrf_802154_trx_standalone_cca_abort(void);
-static void nrf_802154_trx_continuous_carrier_abort(void);
-static void nrf_802154_trx_energy_detection_abort(void);
+static void go_idle_abort(void);
+static void receive_frame_abort(void);
+static void receive_ack_abort(void);
+static void transmit_frame_abort(void);
+static void transmit_ack_abort(void);
+static void standalone_cca_abort(void);
+static void continuous_carrier_abort(void);
+static void energy_detection_abort(void);
 
 /** Clear flags describing frame being received. */
 void rx_flags_clear(void)
@@ -1266,11 +1261,11 @@ void nrf_802154_trx_abort(void)
             break;
 
         case TRX_STATE_GOING_IDLE:
-            nrf_802154_trx_go_idle_abort();
+            go_idle_abort();
             break;
 
         case TRX_STATE_RXFRAME:
-            nrf_802154_trx_receive_frame_abort();
+            receive_frame_abort();
             break;
 
         case TRX_STATE_RXFRAME_FINISHED:
@@ -1279,27 +1274,27 @@ void nrf_802154_trx_abort(void)
             break;
 
         case TRX_STATE_RXACK:
-            nrf_802154_trx_receive_ack_abort();
+            receive_ack_abort();
             break;
 
         case TRX_STATE_TXFRAME:
-            nrf_802154_trx_transmit_frame_abort();
+            transmit_frame_abort();
             break;
 
         case TRX_STATE_TXACK:
-            nrf_802154_trx_transmit_ack_abort();
+            transmit_ack_abort();
             break;
 
         case TRX_STATE_STANDALONE_CCA:
-            nrf_802154_trx_standalone_cca_abort();
+            standalone_cca_abort();
             break;
 
         case TRX_STATE_CONTINUOUS_CARRIER:
-            nrf_802154_trx_continuous_carrier_abort();
+            continuous_carrier_abort();
             break;
 
         case TRX_STATE_ENERGY_DETECTION:
-            nrf_802154_trx_energy_detection_abort();
+            energy_detection_abort();
             break;
 
         default:
@@ -1348,13 +1343,13 @@ bool nrf_802154_trx_go_idle(void)
     return false;
 }
 
-static void nrf_802154_trx_go_idle_abort(void)
+static void go_idle_abort(void)
 {
     nrf_radio_int_disable(NRF_RADIO_INT_DISABLED_MASK);
     m_trx_state = TRX_STATE_FINISHED;
 }
 
-static void nrf_802154_trx_receive_frame_abort(void)
+static void receive_frame_abort(void)
 {
     rxframe_finish_disable_ppis();
     rxframe_finish_disable_fem_activation();
@@ -1413,7 +1408,7 @@ static void rxack_finish(void)
      */
 }
 
-static void nrf_802154_trx_receive_ack_abort(void)
+static void receive_ack_abort(void)
 {
     rxack_finish_disable_ppis();
     rxack_finish_disable_ints();
@@ -1470,7 +1465,7 @@ static void standalone_cca_finish(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-static void nrf_802154_trx_standalone_cca_abort(void)
+static void standalone_cca_abort(void)
 {
     standalone_cca_finish();
 
@@ -1509,7 +1504,7 @@ void nrf_802154_trx_continuous_carrier_restart(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-static void nrf_802154_trx_continuous_carrier_abort(void)
+static void continuous_carrier_abort(void)
 {
     nrf_ppi_channel_disable(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable(PPI_EGU_RAMP_UP);
@@ -1568,7 +1563,7 @@ static void energy_detection_finish(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-static void nrf_802154_trx_energy_detection_abort(void)
+static void energy_detection_abort(void)
 {
     energy_detection_finish();
     m_trx_state = TRX_STATE_FINISHED;
@@ -1740,7 +1735,7 @@ static void txframe_finish(void)
      */
 }
 
-static void nrf_802154_trx_transmit_frame_abort(void)
+static void transmit_frame_abort(void)
 {
     txframe_finish_disable_ppis();
     nrf_radio_shorts_set(SHORTS_IDLE);
@@ -1797,7 +1792,7 @@ static void txack_finish(void)
      */
 }
 
-static void nrf_802154_trx_transmit_ack_abort(void)
+static void transmit_ack_abort(void)
 {
     nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
 

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -193,6 +193,15 @@ static nrf_802154_flags_t m_flags; ///< Flags used to store the current driver s
 static volatile uint32_t m_timer_value_on_radio_end_event;
 static volatile bool     m_transmit_with_cca;
 
+static void nrf_802154_trx_go_idle_abort(void);
+static void nrf_802154_trx_receive_frame_abort(void);
+static void nrf_802154_trx_receive_ack_abort(void);
+static void nrf_802154_trx_transmit_frame_abort(void);
+static void nrf_802154_trx_transmit_ack_abort(void);
+static void nrf_802154_trx_standalone_cca_abort(void);
+static void nrf_802154_trx_continuous_carrier_abort(void);
+static void nrf_802154_trx_energy_detection_abort(void);
+
 /** Clear flags describing frame being received. */
 void rx_flags_clear(void)
 {
@@ -1319,13 +1328,13 @@ bool nrf_802154_trx_go_idle(void)
     return false;
 }
 
-void nrf_802154_trx_go_idle_abort(void)
+static void nrf_802154_trx_go_idle_abort(void)
 {
     nrf_radio_int_disable(NRF_RADIO_INT_DISABLED_MASK);
     m_trx_state = TRX_STATE_FINISHED;
 }
 
-void nrf_802154_trx_receive_frame_abort(void)
+static void nrf_802154_trx_receive_frame_abort(void)
 {
     rxframe_finish_disable_ppis();
     rxframe_finish_disable_fem_activation();
@@ -1384,7 +1393,7 @@ static void rxack_finish(void)
      */
 }
 
-void nrf_802154_trx_receive_ack_abort(void)
+static void nrf_802154_trx_receive_ack_abort(void)
 {
     rxack_finish_disable_ppis();
     rxack_finish_disable_ints();
@@ -1441,7 +1450,7 @@ static void standalone_cca_finish(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-void nrf_802154_trx_standalone_cca_abort(void)
+static void nrf_802154_trx_standalone_cca_abort(void)
 {
     standalone_cca_finish();
 
@@ -1480,7 +1489,7 @@ void nrf_802154_trx_continuous_carrier_restart(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-void nrf_802154_trx_continuous_carrier_abort(void)
+static void nrf_802154_trx_continuous_carrier_abort(void)
 {
     nrf_ppi_channel_disable(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable(PPI_EGU_RAMP_UP);
@@ -1539,7 +1548,7 @@ static void energy_detection_finish(void)
     nrf_radio_task_trigger(NRF_RADIO_TASK_DISABLE);
 }
 
-void nrf_802154_trx_energy_detection_abort(void)
+static void nrf_802154_trx_energy_detection_abort(void)
 {
     energy_detection_finish();
     m_trx_state = TRX_STATE_FINISHED;
@@ -1711,7 +1720,7 @@ static void txframe_finish(void)
      */
 }
 
-void nrf_802154_trx_transmit_frame_abort(void)
+static void nrf_802154_trx_transmit_frame_abort(void)
 {
     txframe_finish_disable_ppis();
     nrf_radio_shorts_set(SHORTS_IDLE);
@@ -1768,7 +1777,7 @@ static void txack_finish(void)
      */
 }
 
-void nrf_802154_trx_transmit_ack_abort(void)
+static void nrf_802154_trx_transmit_ack_abort(void)
 {
     nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
 

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -35,15 +35,15 @@
 #include "nrf_802154_const.h"
 #include "nrf_802154_types.h"
 #include "nrf_802154_peripherals.h"
-#include "nrf_802154_pib.h"  // Unwanted dependency, but required yet
-#include "nrf_802154_rssi.h" // Unwanted dependency, but required yet
+#include "nrf_802154_pib.h"
+#include "nrf_802154_rssi.h"
 #include "nrf_802154_utils.h"
 
 #include "nrf_egu.h"
 #include "nrf_radio.h"
 
-#include "nrf_802154_procedures_duration.h" // Because of RX_RAMP_UP_TIME/TX_RAMP_UP_TIME
-#include "nrf_802154_critical_section.h"    // do we really want to have this dependency
+#include "nrf_802154_procedures_duration.h"
+#include "nrf_802154_critical_section.h"
 #include "fem/nrf_fem_protocol_api.h"
 
 #include "nrf_802154_trx.h"
@@ -293,17 +293,6 @@ static void irq_init(void)
 #endif
     NVIC_SetPriority(RADIO_IRQn, NRF_802154_IRQ_PRIORITY);
     NVIC_ClearPendingIRQ(RADIO_IRQn);
-}
-
-/** Deinitialize interrupts for radio peripheral. */
-/*static*/ void irq_deinit(void)
-{
-    NVIC_DisableIRQ(RADIO_IRQn);
-    NVIC_ClearPendingIRQ(RADIO_IRQn);
-    NVIC_SetPriority(RADIO_IRQn, 0);
-
-    __DSB();
-    __ISB();
 }
 
 /** Wait time needed to propagate event through PPI to EGU.

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -656,7 +656,6 @@ bool nrf_802154_trx_receive_buffer_set(void * p_receive_buffer)
 
     mp_receive_buffer = p_receive_buffer;
 
-    // TODO: critical section?
     if ((p_receive_buffer != NULL) && m_flags.missing_receive_buffer)
     {
         uint32_t shorts = SHORTS_IDLE;
@@ -880,7 +879,6 @@ void nrf_802154_trx_receive_ack(void)
     nrf_radio_int_enable(ints_to_enable);
 
     // Set PPIs necessary in rx_ack state
-    // TODO: Understand what is going on here and why is it different than in nrf_802154_trx_receive_frame
     fem_for_lna_set();
 
     nrf_ppi_channel_and_fork_endpoint_setup(PPI_EGU_RAMP_UP,
@@ -908,13 +906,6 @@ void nrf_802154_trx_receive_ack(void)
     nrf_ppi_channel_enable(PPI_DISABLED_EGU);
 
     trigger_disable_to_start_rampup();
-
-// TODO: Move this stuff outside
-// UPDATE: Ack matching will be done in software, not by using those mhr stuff
-// if ((mp_tx_data[FRAME_VERSION_OFFSET] & FRAME_VERSION_MASK) != FRAME_VERSION_2)
-// {
-// ack_matching_enable();
-// }
 }
 
 bool nrf_802154_trx_rssi_measure(void)
@@ -1212,7 +1203,7 @@ static void rxframe_finish(void)
     wait_until_radio_is_disabled(); // This includes waiting since CRCOK/CRCERROR (several cycles) event until END
                                     // and then during RXDISABLE state (0.5us)
 
-    ppi_and_egu_delay_wait();       // TODO: is this time enough?
+    ppi_and_egu_delay_wait();
 
     /* Now it is guaranteed, that:
      * - FEM operation to disable LNA mode is triggered through FEM's PPIs

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -1893,7 +1893,7 @@ static void irq_handler_edend(void)
     nrf_802154_trx_energy_detection_finished(ed_sample);
 }
 
-static void irq_handler(void)
+void nrf_802154_radio_irq_handler(void)
 {
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_IRQ_HANDLER);
 
@@ -2012,9 +2012,8 @@ static void irq_handler(void)
 
 #if NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 void RADIO_IRQHandler(void)
-#else // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
-void nrf_802154_core_irq_handler(void)
-#endif  // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
 {
-    irq_handler();
+    nrf_802154_radio_irq_handler();
 }
+
+#endif  // NRF_802154_INTERNAL_RADIO_IRQ_HANDLING

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -231,7 +231,6 @@ extern void nrf_802154_trx_transmit_frame_transmitted(void);
 extern void nrf_802154_trx_transmit_ack_started(void);
 extern void nrf_802154_trx_transmit_ack_transmitted(void);
 
-
 extern void nrf_802154_trx_go_idle_finished(void);
 
 extern void nrf_802154_trx_standalone_cca_finished(bool channel_was_idle);

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -123,7 +123,7 @@ void nrf_802154_trx_cca_configuration_update(void);
  * When in @ref nrf_802154_trx_receive_frame_received, the TIMER is running allowing sending response (e.g. ACK frame)
  * in time regime by a call to nrf_802154_trx_transmit_after_frame_received.
  *
- * @note To receive ACK use @ref @ref nrf_802154_trx_receive_ack
+ * @note To receive ACK use @ref nrf_802154_trx_receive_ack
  *
  * @param[in] bcc   Number of received bytes after which @ref nrf_802154_trx_receive_frame_bcmatched will be called.
  *                  This must not be zero if @ref NRF_802154_DISABLE_BCC_MATCHING == 0.
@@ -546,7 +546,6 @@ extern void nrf_802154_trx_transmit_ack_transmitted(void);
  * Implementation may leave trx in @c IDLE state or it may request:
  * - @ref nrf_802154_trx_receive_frame,
  * - @ref nrf_802154_trx_transmit_frame,
- * - @ref nrf_802154_trx_go_idle,
  * - @ref nrf_802154_trx_disable.
  */
 extern void nrf_802154_trx_go_idle_finished(void);

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -67,7 +67,7 @@ void nrf_802154_trx_init(void);
  * @warning This function may be called when:
  * - Trx module was in @c DISABLED state (after @ref nrf_802154_trx_init or after @ref nrf_802154_trx_disable).
  * - HFCLK clock is activated.
- * - Access to the @ref RADIO peripheral is granted (applicable when the RADIO is shared with other drivers).
+ * - Access to the RADIO peripheral is granted (applicable when the RADIO is shared with other drivers).
  *
  * @note When trx was in @c DISABLED state, the RADIO might have been controlled by other drivers. Thus
  * full reset of the RADIO peripheral is performed.
@@ -85,8 +85,8 @@ void nrf_802154_trx_enable(void);
  * - Trx module is in @c DISABLED state
  *
  * @note On call to this function any activity of trx module is stopped. If any operation was executing, it
- * will be stopped and no handler will be called. After call HFCLK may be deactivated and cto
- * the @ref RADIO peripheral may be passed
+ * will be stopped and no handler will be called. After call HFCLK may be deactivated and
+ * the RADIO peripheral may be passed to other driver.
  */
 void nrf_802154_trx_disable(void);
 
@@ -105,7 +105,7 @@ void nrf_802154_trx_cca_configuration_update(void);
  *
  * When NRF_802154_DISABLE_BCC_MATCHING == 0
  * - during receive @ref nrf_802154_trx_receive_frame_bcmatched handler is called when
- *   bcc octets are received.
+ *   @p bcc octets are received.
  * - when a frame is received with correct crc, @ref nrf_802154_trx_receive_frame_received is called
  * - when a frame is received with incorrect crc, @ref nrf_802154_trx_receive_frame_crcerror is called
  *
@@ -345,7 +345,7 @@ extern void nrf_802154_trx_receive_ack_started(void);
  * This handler is called from an ISR when given number of bytes (see @ref nrf_802154_trx_receive)
  * have been just received.
  *
- * @note If the handler decides to abort receive by a call to @ref nrf_802154_trx_receive_abort or
+ * @note If the handler decides to abort receive by a call to @ref nrf_802154_trx_abort or
  *       @ref nrf_802154_trx_disable it must return value equal to original bcc parameter passed.
  *
  * @param[in]   bcc   Number of bytes that have been already received.

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -270,9 +270,9 @@ void nrf_802154_trx_transmit_frame(const void * p_transmit_buffer, bool cca);
  *
  * @retval true     If the function was called in time and ACK frame is scheduled for transmission.
  *                  When transmission starts and @ref NRF_802154_TX_STARTED_NOTIFY_ENABLED != 0
- *                  the function @ref nrf_802154_trx_transmit_started(@ref TRX_STATE_TXACK) will be called.
- *                  When transmission is finished the function @ref nrf_802154_trx_transmit_transmitted(@ref TRX_STATE_TXACK)
- *                  function will be called.
+ *                  the function @ref nrf_802154_trx_transmit_ack_started will be called.
+ *                  When transmission is finished the function @ref nrf_802154_trx_transmit_ack_transmitted
+ *                  will be called.
  * @retval false    If the function was called too late and given delay_us time gap
  *                  between received frame and ACK frame transmission could not be hold.
  *                  The TIMER peripheral is stopped and it is not possible to trigger @ref nrf_802154_trx_transmit_ack
@@ -500,6 +500,7 @@ extern void nrf_802154_trx_transmit_frame_transmitted(void);
 /**@brief Handler called when ack transmission has just been started.
  *
  * This handler is called from an ISR when:
+ * - @ref NRF_802154_TX_STARTED_NOTIFY_ENABLED == 1 (see nrf_802154_config.h)
  * - transmit operation was started by a call to @ref nrf_802154_trx_transmit_ack.
  * - the RADIO peripheral sent synchronization header
  *

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -47,37 +47,6 @@
 extern "C" {
 #endif
 
-typedef enum
-{
-    TRX_STATE_DISABLED = 0,
-    TRX_STATE_IDLE,
-    TRX_STATE_GOING_IDLE,
-    TRX_STATE_RXFRAME,
-
-    /* PPIS disabled deconfigured
-     * RADIO is DISABLED, RXDISABLE
-     * RADIO shorts are 0
-     * TIMER is running
-     * FEM is going to powered or is powered depending if RADIO reached DISABLED
-     */
-    TRX_STATE_RXFRAME_FINISHED,
-
-    TRX_STATE_RXACK,
-    TRX_STATE_TXFRAME,
-    TRX_STATE_TXACK,
-    TRX_STATE_STANDALONE_CCA,
-    TRX_STATE_CONTINUOUS_CARRIER,
-    TRX_STATE_ENERGY_DETECTION,
-
-    /* PPIS disabled deconfigured
-     * RADIO is DISABLED, TXDISABLE, RXDISABLE
-     * RADIO shorts are 0
-     * TIMER is stopped
-     * FEM is going to powered or is powered depending if RADIO reached DISABLED
-     */
-    TRX_STATE_FINISHED
-} trx_state_t;
-
 /**@brief Initializes trx module.
  *
  * This function must be called exactly once, before any other API call.
@@ -227,10 +196,10 @@ void nrf_802154_trx_energy_detection(uint32_t ed_count);
 
 void nrf_802154_trx_abort(void);
 
-/**@brief   Handler called from isr at the beginning of a frame reception (just after synchronization header is received).
+/**@brief   Handler called from isr at the beginning of a ACK reception (just after synchronization header is received).
  * @note Proper implementation of this function is out of scope of the trx module.
  */
-extern void nrf_802154_trx_receive_on_shr(trx_state_t state);
+extern void nrf_802154_trx_receive_ack_started(void);
 
 /**@brief  Handler called from isr during reception of a frame, when given number of bytes is received.
  *
@@ -241,21 +210,29 @@ extern void nrf_802154_trx_receive_on_shr(trx_state_t state);
  *
  * @param[in]   bcc   Number of bytes that have been already received.
  *
- * @return  Value greater than original value of bcc parameter will cause @ref nrf_802154_trx_receive_on_bcmatch
+ * @return  Value greater than original value of bcc parameter will cause @ref nrf_802154_trx_receive_frame_bcmatched
  *          to be called again when further data arrive. Value less than or equal to original bcc value will not cause this
  *          behavior.
  *
  */
-extern uint8_t nrf_802154_trx_receive_on_bcmatch(uint8_t bcc);
+extern uint8_t nrf_802154_trx_receive_frame_bcmatched(uint8_t bcc);
 
-extern void nrf_802154_trx_receive_received(trx_state_t state);
-extern void nrf_802154_trx_receive_crcerror(trx_state_t state);
+extern void nrf_802154_trx_receive_frame_received(void);
+extern void nrf_802154_trx_receive_frame_crcerror(void);
 
-extern void nrf_802154_trx_transmit_ccabusy(void);
-extern void nrf_802154_trx_transmit_started(trx_state_t state); // TODO change name nrf_802154_trx_transmit_on_shr
-extern void nrf_802154_trx_transmit_transmitted(trx_state_t state);
+extern void nrf_802154_trx_receive_ack_received(void);
+extern void nrf_802154_trx_receive_ack_crcerror(void);
 
-extern void nrf_802154_trx_in_idle(void);
+extern void nrf_802154_trx_transmit_frame_ccabusy(void);
+
+extern void nrf_802154_trx_transmit_frame_started(void);
+extern void nrf_802154_trx_transmit_frame_transmitted(void);
+
+extern void nrf_802154_trx_transmit_ack_started(void);
+extern void nrf_802154_trx_transmit_ack_transmitted(void);
+
+
+extern void nrf_802154_trx_go_idle_finished(void);
 
 extern void nrf_802154_trx_standalone_cca_finished(bool channel_was_idle);
 

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -49,11 +49,45 @@ extern "C" {
 
 /**@brief Initializes trx module.
  *
- * This function must be called exactly once, before any other API call.
+ * This function must be called exactly once, before any other API call. This function sets internal state
+ * of trx module into @c DISABLED. It initializes also those peripherals that are used exclusively
+ * by trx module and are not shared when trx module is in @c DISABLED state.
  */
 void nrf_802154_trx_init(void);
 
+/**@brief Enables trx module.
+ *
+ * Effects of call to this function:
+ * - The RADIO peripheral is fully reset and configured into 802.15.4 mode.
+ * - FEM module state is set to powered off.
+ * - PPIs used by trx module are disabled.
+ * - TIMER used by trx module is shutdown.
+ * - Trx module is in @c IDLE state
+ *
+ * @warning This function may be called when:
+ * - Trx module was in @c DISABLED state (after @ref nrf_802154_trx_init or after @ref nrf_802154_trx_disable).
+ * - HFCLK clock is activated.
+ * - Access to the @ref RADIO peripheral is granted (applicable when the RADIO is shared with other drivers).
+ *
+ * @note When trx was in @c DISABLED state, the RADIO might have been controlled by other drivers. Thus
+ * full reset of the RADIO peripheral is performed.
+ */
 void nrf_802154_trx_enable(void);
+
+/**@brief Disables trx module.
+ *
+ * This function has no effects when the trx module is in @c DISABLED state.
+ * Otherwise following effects apply:
+ * - The RADIO peripheral is fully reset.
+ * - FEM module state is set to powered off.
+ * - all PPSs used by trx module are disabled and cleared.
+ * - TIMER used by trx module is shutdown.
+ * - Trx module is in @c DISABLED state
+ *
+ * @note On call to this function any activity of trx module is stopped. If any operation was executing, it
+ * will be stopped and no handler will be called. After call HFCLK may be deactivated and cto
+ * the @ref RADIO peripheral may be passed
+ */
 void nrf_802154_trx_disable(void);
 
 /**@brief Sets radio channel to use.
@@ -62,33 +96,36 @@ void nrf_802154_trx_disable(void);
  */
 void nrf_802154_trx_channel_set(uint8_t channel);
 
+/**@brief Updates CCA configuration in the RADIO peripheral according to PIB. */
 void nrf_802154_trx_cca_configuration_update(void);
 
-/**@brief Puts the trx module into receive frame (non-ack) mode.
+/**@brief Puts the trx module into receive frame mode.
  *
  * The frame will be received into buffer set by @ref nrf_802154_trx_receive_buffer_set.
  *
  * When NRF_802154_DISABLE_BCC_MATCHING == 0
- * - during receive @ref nrf_802154_trx_receive_on_bcmatch handler (from ISR) is called when
- *   bcc octets is received.
- * - when a frame is received with correct crc, @ref nrf_802154_trx_receive_received is called (from ISR)
- * - when a frame is received with incorrect crc, @ref nrf_802154_trx_receive_crcerror is called (from ISR)
+ * - during receive @ref nrf_802154_trx_receive_frame_bcmatched handler is called when
+ *   bcc octets are received.
+ * - when a frame is received with correct crc, @ref nrf_802154_trx_receive_frame_received is called
+ * - when a frame is received with incorrect crc, @ref nrf_802154_trx_receive_frame_crcerror is called
  *
  * When NRF_802154_DISABLE_BCC_MATCHING != 0
  * - during receive no handlers (no ISRs) are called
- * - after the frame is received with correct crc, @ref nrf_802154_trx_receive_received is called (from ISR)
+ * - after the frame is received with correct crc, @ref nrf_802154_trx_receive_frame_received is called
  * - after the frame is received with incorrect crc:
  *     - when NRF_802154_NOTIFY_CRCERROR == 0:
+ *         - the hardware restarts receive automatically
  *         - no handler is called
- *         - the hardware restarts receive automatically
  *     - when NRF_802154_NOTIFY_CRCERROR != 0:
- *         - @ref nrf_802154_trx_receive_crcerror is called
  *         - the hardware restarts receive automatically
+ *         - @ref nrf_802154_trx_receive_frame_crcerror is called
  *
- * When in @ref nrf_802154_trx_receive_received TIMER is running allowing sending respone (e.g. ACK frame)
+ * When in @ref nrf_802154_trx_receive_frame_received, the TIMER is running allowing sending response (e.g. ACK frame)
  * in time regime by a call to nrf_802154_trx_transmit_after_frame_received.
  *
- * @param[in] bcc   Number of received bytes after which @ref nrf_802154_trx_receive_on_bcmatch will be called.
+ * @note To receive ACK use @ref @ref nrf_802154_trx_receive_ack
+ *
+ * @param[in] bcc   Number of received bytes after which @ref nrf_802154_trx_receive_frame_bcmatched will be called.
  *                  This must not be zero if @ref NRF_802154_DISABLE_BCC_MATCHING == 0.
  *                  When @ref NRF_802154_DISABLE_BCC_MATCHING != 0, this value must be zero.
  *
@@ -97,18 +134,19 @@ void nrf_802154_trx_receive_frame(uint8_t bcc);
 
 /**@brief Puts the trx module into receive ACK mode.
  *
- * The ack frame will be received into buffer set by @ref nrf_802154_trx_receive_buffer_set
+ * The ack frame will be received into buffer set by @ref nrf_802154_trx_receive_buffer_set.
  *
- * During receive of a frame:
- * - @ref nrf_802154_trx_receive_on_framestart is called when a frame has just started being received.
- * - when a frame is received with correct crc, @ref nrf_802154_trx_receive_received is called (from ISR)
- * - when a frame is received with incorrect crc, @ref nrf_802154_trx_receive_crcerror is called (from ISR)
+ * During receive of an ack:
+ * - @ref nrf_802154_trx_receive_ack_started is called when a frame has just started being received.
+ * - when a frame is received with correct crc, @ref nrf_802154_trx_receive_ack_received is called.
+ * - when a frame is received with incorrect crc, @ref nrf_802154_trx_receive_ack_crcerror is called.
+ * - no bcmatch events are generated.
  */
 void nrf_802154_trx_receive_ack(void);
 
 /**@brief Starts RSSI measurement.
  *
- * @note This function succeeds when TRX module is in receive frame state only.
+ * @note This function succeeds when TRX module is in receive frame state only (started with @ref nrf_802154_trx_receive_frame)
  *
  * @retval true     When RSSI measurement has been started.
  * @retval false    When TRX state didn't allow start of RSSI measurement.
@@ -138,29 +176,96 @@ uint8_t nrf_802154_trx_rssi_last_sample_get(void);
 
 /**@brief Check if PSDU is currently being received.
  *
- * @retval true     If trx is in receive mode triggered by nrf_802154_trx_receive_frame and
- *                  a frame receive has been started but not finished yet.
+ * @retval true     If trx is in receive mode triggered by @ref nrf_802154_trx_receive_frame and
+ *                  a frame receive on air has been started but not finished yet.
  * @retval false    Otherwise.
  *
- * @note This function returns false when receive has been triggered by nrf_802154_trx_receive_ack
+ * @note This function returns false when receive has been triggered by @ref nrf_802154_trx_receive_ack
  *       regardless of the fact if the frame on air has been started or not.
  */
 bool nrf_802154_trx_psdu_is_being_received(void);
 
+/**@brief Checks if current receive operation was started without providing receive buffer.
+ *
+ * It may happen that @ref nrf_802154_trx_receive_frame or @ref nrf_802154_trx_receive_ack have been started
+ * when there was no receive buffer set. The RADIO peripheral will start ramping up, but it will remain
+ * in @c RXIDLE state, because of missing receive buffer. This function allows to check if such situation
+ * occurred.
+ *
+ * Usually this function may be called by buffer management subsystem when buffer becomes available.
+ * Consider following code snippet:
+ * @code
+ * void buffer_is_available_callback(void * p_buffer)
+ * {
+ *     if (nrf_802154_trx_receive_is_buffer_missing())
+ *     {
+ *         nrf_802154_trx_receive_buffer_set(p_buffer);
+ *     }
+ * }
+ * @endcode
+ *
+ * @retval true When in receive mode and receive buffer is missing
+ * @retval false Otherwise.
+ */
 bool nrf_802154_trx_receive_is_buffer_missing(void);
 
+/**@brief Sets pointer to a receive buffer.
+ *
+ * @param p_receive_buffer If NULL the next call to @ref nrf_802154_trx_receive_frame or
+ *                         @ref nrf_802154_trx_receive_ack will not be able to receive.
+ *                         If not NULL it must point to MAX_PACKET_SIZE + 1 (see nrf_802154_const.h)
+ *                         buffer where received frame will be stored.
+ *
+ * @retval true  If operation solved missing buffer condition (see @ref nrf_802154_trx_receive_is_buffer_missing)
+ *               and provided buffer will be used in current receive operation.
+ * @retval false If operation didn't solve missing buffer condition (either no missing buffer or currently
+ *               not in receive mode). Provided buffer will be used in next receive operation.
+ */
 bool nrf_802154_trx_receive_buffer_set(void * p_receive_buffer);
 
+/**@brief Begins frame transmit operation.
+ *
+ * This operation performs differently according to cca parameter.
+ * When cca==false:
+ * - The RADIO starts ramp up in transmit mode.
+ * - The RADIO starts sending synchronization header (SHR).
+ * - @ref nrf_802154_trx_transmit_frame_started handler is called from an ISR just after SHR is sent
+ *   (only when @ref NRF_802154_TX_STARTED_NOTIFY_ENABLED == 1).
+ * - @ref nrf_802154_trx_transmit_frame_transmitted handler is called from an ISR after full frame is sent on air.
+ *
+ * When cca==true:
+ * - The radio starts ramp up in receive mode, then it starts cca procedure.
+ * - If cca succeded (channel was idle):
+ *     - The RADIO switches to transmit mode (disables receive mode, starts ramp up in transmit mode).
+ *     - The RADIO starts sending sending synchronization header (SHR).
+ *     - @ref nrf_802154_trx_transmit_frame_started handler is called from an ISR just after SHR is sent
+ *       (only when @ref NRF_802154_TX_STARTED_NOTIFY_ENABLED == 1).
+ *     - @ref nrf_802154_trx_transmit_frame_transmitted handler is called from an ISR after full frame is sent on air.
+ * - If cca failed (channel was busy):
+ *     - The RADIO disables receive mode
+ *     - @ref nrf_802154_trx_transmit_frame_ccabusy from an ISR handler is called
+ *
+ * @param p_transmit_buffer Pointer to a buffer containing frame to transmit.
+ *                          Must not be NULL. p_transmit_buffer[0] is the number of
+ *                          bytes following p_transmit_buffer[0] to send.
+ *                          The number of bytes pointed by p_transmit buffer must
+ *                          be at least 1 and not less than p_transmit_buffer[0] + 1.
+ *
+ * @param cca               Selects if CCA procedure should be performed prior to
+ *                          real transmission. If false no cca will be performed.
+ *                          If true, cca will be performed.
+ *
+ * @note To transmit ack after frame is received use @ref nrf_802154_trx_transmit_ack.
+ */
 void nrf_802154_trx_transmit_frame(const void * p_transmit_buffer, bool cca);
 
 /**@brief Puts the trx module into transmit ACK mode.
  *
- *
- * @note This function may be called from @ref nrf_802154_trx_receive_received handler
- *       with state == TRX_STATE_RXFRAME passed only. This is because in this condition only
- *       the TIMER peripheral is running and allows timed transmission.
+ * @note This function may be called from @ref nrf_802154_trx_receive_received handler only.
+ *       This is because in this condition only the TIMER peripheral is running and allows timed transmission.
  *
  * @param[in] p_transmit_buffer     Pointer to a buffer containing ACK frame to be transmitted.
+ *                                  Caller is responsible for preparing an ACK frame according to the 802.15.4 protocol.
  * @param[in] delay_us              Delay (in microseconds)
  *
  * @retval true     If the function was called in time and ACK frame is scheduled for transmission.
@@ -171,70 +276,320 @@ void nrf_802154_trx_transmit_frame(const void * p_transmit_buffer, bool cca);
  * @retval false    If the function was called too late and given delay_us time gap
  *                  between received frame and ACK frame transmission could not be hold.
  *                  The TIMER peripheral is stopped and it is not possible to trigger @ref nrf_802154_trx_transmit_ack
- *                  again without receiving another frame again. No callbacks will be called.
+ *                  again without receiving another frame again. No handlers will be called.
  */
 bool nrf_802154_trx_transmit_ack(const void * p_transmit_buffer, uint32_t delay_us);
 
+/**@brief Puts trx module into IDLE mode.
+ *
+ * @retval true     If entering into IDLE mode started, @ref nrf_802154_trx_go_idle_finished will be called
+ *                  (if not aborted by call to @ref nrf_802154_trx_abort or nrf_802154_trx_disable).
+ * @retval false    If already in IDLE mode or just requested @ref nrf_802154_trx_go_idle. There will be
+ *                  no @ref nrf_802154_trx_go_idle_finished handler being result of this function.
+ */
 bool nrf_802154_trx_go_idle(void);
 
+/**@brief Starts standalone cca operation.
+ *
+ * Operation ends with a call to @ref nrf_802154_trx_standalone_cca_finished handler from an ISR.
+ */
 void nrf_802154_trx_standalone_cca(void);
 
+/**@brief Starts generating continuous carrier.
+ *
+ * Generation of a continuous carrier generates no handlers. It may be terminated by a call to
+ * @ref nrf_802154_trx_abort or @ref nrf_802154_trx_disable.
+ */
 void nrf_802154_trx_continuous_carrier(void);
+
+/**@brief Restarts generating continuous carrier
+ *
+ * When continuous carrier was being generated and channel change was requested by a call to @ref nrf_802154_trx_channel_set.
+ * The frequency is not changed automatically. Use @ref nrf_802154_trx_continuous_carrier_restart to
+ * stop generating continuous carrier on old frequency and start this operation on a new frequency.
+ * @ref nrf_802154_trx_continuous_carrier_restart is usually faster than
+ * call to @ref nrf_802154_trx_abort @ref nrf_802154_trx_continuous_carrier
+ */
 void nrf_802154_trx_continuous_carrier_restart(void);
 
 /**@brief Puts trx module into energy detection mode.
  *
- * Operation ends up with a call to ref nrf_802154_trx_energy_detection_finished
+ * Operation ends up with a call to @ref nrf_802154_trx_energy_detection_finished handler.
  *
- * Operation can be terminated with a call to @ref nrf_802154_trx_energy_detection_abort,
- * @ref nrf_802154_trx_abort or @ref nrf_802154_trx_disable. In this case no callback is called.
+ * Operation can be terminated with a call to @ref nrf_802154_trx_abort or @ref nrf_802154_trx_disable.
+ * In this case no handler is called.
  *
- * @param ed_count  Number of iterations to perform. Must be in range 1..2097152 (TODO: where define it)
- *                  One iteration takes (TODO: define, in procedures_duration.h?) 128us
+ * @param ed_count  Number of iterations to perform. Must be in range 1..2097152.
+ *                  One iteration takes 128 microseconds.
  */
 void nrf_802154_trx_energy_detection(uint32_t ed_count);
 
+/**@brief Aborts currently performed operation.
+ *
+ * When trx module is in @c DISABLED, @c IDLE or @c FINISHED state, this function has no effect.
+ * Otherwise current operation is terminated and no handler will be generated by the operation
+ * regardless of its state. In this case trx module will be in @c FINISHED state allowing
+ * commencement of a next operation.
+ */
 void nrf_802154_trx_abort(void);
 
-/**@brief   Handler called from isr at the beginning of a ACK reception (just after synchronization header is received).
- * @note Proper implementation of this function is out of scope of the trx module.
+/**@brief Handler called at the beginning of a ACK reception.
+ *
+ * This handler is called from an ISR when receive of an ack has been started, and
+ * the RADIO received synchronization header (SHR).
  */
 extern void nrf_802154_trx_receive_ack_started(void);
 
-/**@brief  Handler called from isr during reception of a frame, when given number of bytes is received.
+/**@brief  Handler called during reception of a frame, when given number of bytes is received.
  *
- * @note Proper implementation of this function is out of scope of the trx module.
+ * This handler is called from an ISR when given number of bytes (see @ref nrf_802154_trx_receive)
+ * have been just received.
  *
- * @note If the handler decides to abort receive by a call to (TODO) @ref nrf_802154_trx_receive_abort
- * it must return value equal to original bcc parameter passed.
+ * @note If the handler decides to abort receive by a call to @ref nrf_802154_trx_receive_abort or
+ *       @ref nrf_802154_trx_disable it must return value equal to original bcc parameter passed.
  *
  * @param[in]   bcc   Number of bytes that have been already received.
  *
  * @return  Value greater than original value of bcc parameter will cause @ref nrf_802154_trx_receive_frame_bcmatched
  *          to be called again when further data arrive. Value less than or equal to original bcc value will not cause this
  *          behavior.
- *
  */
 extern uint8_t nrf_802154_trx_receive_frame_bcmatched(uint8_t bcc);
 
+/**@brief Handler called when a frame is received with correct crc.
+ *
+ * This handler is called from an ISR when:
+ * - receive operation has been started with a call to @ref nrf_802154_trx_receive_frame
+ * - the RADIO received a frame on air with correct crc
+ *
+ * When this handler is called following holds:
+ * - trx module is in @c RXFRAME_FINISHED state.
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - TIMER peripheral started counting allowing @ref nrf_802154_trx_transmit_ack
+ *
+ * Implementation of @ref nrf_802154_trx_receive_frame_received is responsible for
+ * leaving @c RXFRAME_FINISHED state. It may do this by call to:
+ * - @ref nrf_802154_trx_transmit_ack,
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_receive_frame_received(void);
+
+/**@brief Handler called when a frame is received with incorrect crc.
+ *
+ * This handler is called from an ISR when:
+ * - receive operation has been started with a call to @ref nrf_802154_trx_receive_frame
+ * - the RADIO received a frame on air with incorrect crc
+ *
+ * If NRF_802154_DISABLE_BCC_MATCHING == 0:
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state.
+ *
+ * Implementation of @ref nrf_802154_trx_receive_frame_crcerror is responsible for
+ * leaving @c FINISHED state. It may do this by call to:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ *
+ * If NRF_802154_DISABLE_BCC_MATCHING != 0:
+ * - the RADIO peripheral is restarted automatically (by hardware) in receive mode
+ * - trx module stays in @c RXFRAME state
+ * Implementation of @ref nrf_802154_trx_receive_frame_crcerror should not call
+ * @ref nrf_802154_trx_receive_frame as receive is restarted automatically by the hardware.
+ * If the implementation wishes to change state it should call
+ * @ref nrf_802154_trx_abort first.
+ */
 extern void nrf_802154_trx_receive_frame_crcerror(void);
 
+/**@brief Handler called when an ack is received with correct crc.
+ *
+ * This handler is called from an ISR when:
+ * - receive ack operation has been started with a call to @ref nrf_802154_trx_receive_ack
+ * - the RADIO received a frame on air with correct crc
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state.
+ *
+ * Implementation is responsible for:
+ * - checking if received frame is an ack and matches previously transmitted frame.
+ * - leaving @c FINISHED state. It may do this by call to:
+ *     - @ref nrf_802154_trx_receive_frame,
+ *     - @ref nrf_802154_trx_transmit_frame,
+ *     - @ref nrf_802154_trx_go_idle,
+ *     - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_receive_ack_received(void);
+
+/**@brief Handler called when an ack is received with incorrect crc.
+ *
+ * This handler is called from an ISR when:
+ * - receive ack operation has been started with a call to @ref nrf_802154_trx_receive_ack
+ * - the RADIO received a frame on air with incorrect crc
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state.
+ *
+ * Implementation is responsible for:
+ * - leaving @c FINISHED state. It may do this by call to:
+ *     - @ref nrf_802154_trx_receive_frame,
+ *     - @ref nrf_802154_trx_transmit_frame,
+ *     - @ref nrf_802154_trx_go_idle,
+ *     - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_receive_ack_crcerror(void);
 
+/**@brief Handler called when a cca operation during transmit attempt failed.
+ *
+ * This handler is called from an ISR when:
+ * - transmit operation with cca has been started with a call to @ref nrf_802154_transmit_frame(cca=true).
+ * - the RADIO detected that channel was busy.
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state.
+ *
+ * Implementation is responsible for:
+ * - leaving @c FINISHED state. It may do this by call to:
+ *     - @ref nrf_802154_trx_receive_frame,
+ *     - @ref nrf_802154_trx_transmit_frame,
+ *     - @ref nrf_802154_trx_go_idle,
+ *     - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_transmit_frame_ccabusy(void);
 
+/**@brief Handler called when frame transmission has just started.
+ *
+ * This handler is called from an ISR when:
+ * - @ref NRF_802154_TX_STARTED_NOTIFY_ENABLED == 1 (see nrf_802154_config.h)
+ * - transmit operation was started by a call to @ref nrf_802154_trx_transmit_frame.
+ * - the RADIO peripheral sent synchronization header
+ *
+ * When this handler is called following holds:
+ * - trx module is in @c TXFRAME state
+ *
+ * Implementation may (but does not need to) terminate transmission if it wishes by a call to:
+ * - @ref nrf_802154_trx_abort,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_transmit_frame_started(void);
+
+/**@brief Handler called when frame transmission has just been finished.
+ *
+ * This handler is called from an ISR when:
+ * - transmit operation was started by a call to @ref nrf_802154_trx_transmit_frame.
+ * - the RADIO peripheral sent whole frame on air
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state
+ *
+ * Implementation is responsible for leaving @c FINISHED state by a call to:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_transmit_frame_transmitted(void);
 
+/**@brief Handler called when ack transmission has just been started.
+ *
+ * This handler is called from an ISR when:
+ * - transmit operation was started by a call to @ref nrf_802154_trx_transmit_ack.
+ * - the RADIO peripheral sent synchronization header
+ *
+ * When this handler is called following holds:
+ * - trx module is in @c TXACK state
+ *
+ * Implementation may (but does not need to) terminate transmission if it wishes by a call to:
+ * - @ref nrf_802154_trx_abort,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_transmit_ack_started(void);
+
+/**@brief Handler called when ack transmission has just been finished.
+ *
+ * This handler is called from an ISR when:
+ * - transmit operation was started by a call to @ref nrf_802154_trx_transmit_ack.
+ * - the RADIO peripheral sent whole ack frame on air
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state
+ *
+ * Implementation is responsible for leaving @c FINISHED state by a call to:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_transmit_ack_transmitted(void);
 
+/**@brief Handler called when trx module reached @c IDLE state.
+ *
+ * This handler is called from an ISR when:
+ * - transition to idle state was successfully requested by a call to @ref nrf_802154_trx_go_idle.
+ * - the RADIO peripheral reached DISABLED state
+ * - the FEM module has been powered off
+ *
+ * When this handler is called following holds:
+ * - the RADIO is in @c DISABLED state
+ * - the FEM is powered off
+ * - trx module is in @c IDLE state
+ *
+ * Implementation may leave trx in @c IDLE state or it may request:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ */
 extern void nrf_802154_trx_go_idle_finished(void);
 
+/**@brief Handler called when standalone cca operaion has been just finished.
+ *
+ *  This handler is called from an ISR when:
+ *  - standalone cca operation was requested by a call to @ref nrf_802154_trx_standalone_cca
+ *  - the RADIO peripheral finished cca operation
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state
+ *
+ * Implementation is responsible for leaving @c FINISHED state by a call to:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ *
+ * @param channel_was_idle  Informs implementation of the handler if channel was idle.
+ *                          true means the channel was idle, false means the channel was busy.
+ */
 extern void nrf_802154_trx_standalone_cca_finished(bool channel_was_idle);
 
+/**@brief Handler called when energy detection operation has been just finished.
+ *
+ *  This handler is called from an ISR when:
+ *  - energy detection operation was requested by a call to @ref nrf_802154_trx_energy_detection
+ *  - the RADIO peripheral finished the operation
+ *
+ * When this handler is called following holds:
+ * - the RADIO peripheral started ramping down (or it ramped down already)
+ * - trx module is in @c FINISHED state
+ *
+ * Implementation is responsible for leaving @c FINISHED state by a call to:
+ * - @ref nrf_802154_trx_receive_frame,
+ * - @ref nrf_802154_trx_transmit_frame,
+ * - @ref nrf_802154_trx_go_idle,
+ * - @ref nrf_802154_trx_disable.
+ *
+ * @param channel_was_idle  Informs implementation of the handler if channel was idle.
+ *                          true means the channel was idle, false means the channel was busy.
+ */
 extern void nrf_802154_trx_energy_detection_finished(uint8_t ed_sample);
 
 #ifdef __cplusplus

--- a/src/nrf_802154_trx.h
+++ b/src/nrf_802154_trx.h
@@ -227,15 +227,6 @@ void nrf_802154_trx_energy_detection(uint32_t ed_count);
 
 void nrf_802154_trx_abort(void);
 
-void nrf_802154_trx_go_idle_abort(void);
-void nrf_802154_trx_receive_frame_abort(void);
-void nrf_802154_trx_receive_ack_abort(void);
-void nrf_802154_trx_transmit_frame_abort(void);
-void nrf_802154_trx_transmit_ack_abort(void);
-void nrf_802154_trx_standalone_cca_abort(void);
-void nrf_802154_trx_continuous_carrier_abort(void);
-void nrf_802154_trx_energy_detection_abort(void);
-
 /**@brief   Handler called from isr at the beginning of a frame reception (just after synchronization header is received).
  * @note Proper implementation of this function is out of scope of the trx module.
  */


### PR DESCRIPTION
Moved nrf_802154_radio_irq_handler from nrf_802154.c to trx.
Removed TODO comments from core and trx.
Moved individual  nrf_802154_trx_xxxx_abort prototyped to trx.c, they are static now. API of trx is simpler now.
Removed trx_state_t from nrf_802154_trx.h header
Refactored some trx function names
Splitted trx callbacks to not pass internal trx state
Updated doxygen codumentation for trx

