### PR TITLE
Pr/refactor critical sections

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -203,21 +203,13 @@ static void received_frame_notify(uint8_t * p_data)
 /** Allow nesting critical sections and notify MAC layer that a frame was received. */
 static void received_frame_notify_and_nesting_allow(uint8_t * p_data)
 {
-    nrf_802154_critical_section_nesting_allow();
-
     received_frame_notify(p_data);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Notify MAC layer that receive procedure failed. */
 static void receive_failed_notify(nrf_802154_rx_error_t error)
 {
-    nrf_802154_critical_section_nesting_allow();
-
     nrf_802154_notify_receive_failed(error);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Notify MAC layer that transmission of requested frame has started. */
@@ -248,12 +240,8 @@ static void transmitted_frame_notify(uint8_t * p_ack, int8_t power, uint8_t lqi)
 {
     const uint8_t * p_frame = mp_tx_data;
 
-    nrf_802154_critical_section_nesting_allow();
-
     nrf_802154_core_hooks_transmitted(p_frame);
     nrf_802154_notify_transmitted(p_frame, p_ack, power, lqi);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Notify MAC layer that transmission procedure failed. */
@@ -270,31 +258,19 @@ static void transmit_failed_notify(nrf_802154_tx_error_t error)
 /** Allow nesting critical sections and notify MAC layer that transmission procedure failed. */
 static void transmit_failed_notify_and_nesting_allow(nrf_802154_tx_error_t error)
 {
-    nrf_802154_critical_section_nesting_allow();
-
     transmit_failed_notify(error);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Notify MAC layer that energy detection procedure ended. */
 static void energy_detected_notify(uint8_t result)
 {
-    nrf_802154_critical_section_nesting_allow();
-
     nrf_802154_notify_energy_detected(result);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Notify MAC layer that CCA procedure ended. */
 static void cca_notify(bool result)
 {
-    nrf_802154_critical_section_nesting_allow();
-
     nrf_802154_notify_cca(result);
-
-    nrf_802154_critical_section_nesting_deny();
 }
 
 /** Check if timeslot is currently granted.
@@ -672,7 +648,6 @@ static bool current_operation_terminate(nrf_802154_term_t term_lvl,
 /** Enter Sleep state. */
 static void sleep_init(void)
 {
-    nrf_802154_trx_disable();
     nrf_802154_timer_coord_stop();
 }
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -200,12 +200,6 @@ static void received_frame_notify(uint8_t * p_data)
                                lqi_get(p_data));            // lqi
 }
 
-/** Allow nesting critical sections and notify MAC layer that a frame was received. */
-static void received_frame_notify_and_nesting_allow(uint8_t * p_data)
-{
-    received_frame_notify(p_data);
-}
-
 /** Notify MAC layer that receive procedure failed. */
 static void receive_failed_notify(nrf_802154_rx_error_t error)
 {
@@ -253,12 +247,6 @@ static void transmit_failed_notify(nrf_802154_tx_error_t error)
     {
         nrf_802154_notify_transmit_failed(p_frame, error);
     }
-}
-
-/** Allow nesting critical sections and notify MAC layer that transmission procedure failed. */
-static void transmit_failed_notify_and_nesting_allow(nrf_802154_tx_error_t error)
-{
-    transmit_failed_notify(error);
 }
 
 /** Notify MAC layer that energy detection procedure ended. */
@@ -830,14 +818,14 @@ static void on_timeslot_ended(void)
             case RADIO_STATE_TX_ACK:
                 state_set(RADIO_STATE_RX);
                 mp_current_rx_buffer->free = false;
-                received_frame_notify_and_nesting_allow(mp_current_rx_buffer->data);
+                received_frame_notify(mp_current_rx_buffer->data);
                 break;
 
             case RADIO_STATE_CCA_TX:
             case RADIO_STATE_TX:
             case RADIO_STATE_RX_ACK:
                 state_set(RADIO_STATE_RX);
-                transmit_failed_notify_and_nesting_allow(NRF_802154_TX_ERROR_TIMESLOT_ENDED);
+                transmit_failed_notify(NRF_802154_TX_ERROR_TIMESLOT_ENDED);
                 break;
 
             case RADIO_STATE_ED:
@@ -889,14 +877,14 @@ static void on_preconditions_denied(radio_state_t state)
         case RADIO_STATE_TX_ACK:
             state_set(RADIO_STATE_RX);
             mp_current_rx_buffer->free = false;
-            received_frame_notify_and_nesting_allow(mp_current_rx_buffer->data);
+            received_frame_notify(mp_current_rx_buffer->data);
             break;
 
         case RADIO_STATE_CCA_TX:
         case RADIO_STATE_TX:
         case RADIO_STATE_RX_ACK:
             state_set(RADIO_STATE_RX);
-            transmit_failed_notify_and_nesting_allow(NRF_802154_TX_ERROR_ABORTED);
+            transmit_failed_notify(NRF_802154_TX_ERROR_ABORTED);
             break;
 
         case RADIO_STATE_ED:
@@ -1161,7 +1149,7 @@ void nrf_802154_trx_receive_frame_received(void)
             nrf_802154_pib_promiscuous_get())
         {
             mp_current_rx_buffer->free = false;
-            received_frame_notify_and_nesting_allow(p_received_data);
+            received_frame_notify(p_received_data);
         }
 
         return;
@@ -1200,7 +1188,7 @@ void nrf_802154_trx_receive_frame_received(void)
                     state_set(RADIO_STATE_RX);
                     rx_init(true);
 
-                    received_frame_notify_and_nesting_allow(p_received_data);
+                    received_frame_notify(p_received_data);
                 }
             }
             else
@@ -1210,7 +1198,7 @@ void nrf_802154_trx_receive_frame_received(void)
                 state_set(RADIO_STATE_RX);
                 rx_init(true);
 
-                received_frame_notify_and_nesting_allow(p_received_data);
+                received_frame_notify(p_received_data);
             }
         }
         else
@@ -1228,7 +1216,7 @@ void nrf_802154_trx_receive_frame_received(void)
 
                 rx_init(true);
 
-                received_frame_notify_and_nesting_allow(p_received_data);
+                received_frame_notify(p_received_data);
             }
             else
             {
@@ -1280,7 +1268,7 @@ void nrf_802154_trx_transmit_ack_transmitted(void)
 
     rx_init(true);
 
-    received_frame_notify_and_nesting_allow(p_received_data);
+    received_frame_notify(p_received_data);
 }
 
 void nrf_802154_trx_transmit_frame_transmitted(void)
@@ -1404,7 +1392,7 @@ static void on_bad_ack(void)
 
     rx_init(true);
 
-    transmit_failed_notify_and_nesting_allow(NRF_802154_TX_ERROR_INVALID_ACK);
+    transmit_failed_notify(NRF_802154_TX_ERROR_INVALID_ACK);
 }
 
 void nrf_802154_trx_receive_ack_received(void)
@@ -1444,7 +1432,7 @@ void nrf_802154_trx_transmit_frame_ccabusy(void)
     state_set(RADIO_STATE_RX);
     rx_init(true);
 
-    transmit_failed_notify_and_nesting_allow(NRF_802154_TX_ERROR_BUSY_CHANNEL);
+    transmit_failed_notify(NRF_802154_TX_ERROR_BUSY_CHANNEL);
 }
 
 void nrf_802154_trx_energy_detection_finished(uint8_t ed_sample)

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -642,13 +642,6 @@ static void sleep_init(void)
 /** Initialize Falling Asleep operation. */
 static void falling_asleep_init(void)
 {
-    if (!timeslot_is_granted())
-    {
-        sleep_init();
-        state_set(RADIO_STATE_SLEEP);
-        return;
-    }
-
     if (nrf_802154_trx_go_idle())
     {
         // There will be nrf_802154_trx_in_idle call, where we will continue processing
@@ -1511,8 +1504,16 @@ bool nrf_802154_core_sleep(nrf_802154_term_t term_lvl)
 
             if (result)
             {
-                state_set(RADIO_STATE_FALLING_ASLEEP);
-                falling_asleep_init();
+                if (!timeslot_is_granted())
+                {
+                    sleep_init();
+                    state_set(RADIO_STATE_SLEEP);
+                }
+                else
+                {
+                    state_set(RADIO_STATE_FALLING_ASLEEP);
+                    falling_asleep_init();
+                }
             }
         }
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1504,6 +1504,8 @@ bool nrf_802154_core_sleep(nrf_802154_term_t term_lvl)
 
             if (result)
             {
+                // Inverted order of calls in the if-else clause below is intentional
+                // and is necessary to prevent RAAL race conditions.
                 if (!timeslot_is_granted())
                 {
                     sleep_init();

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -92,18 +92,6 @@ static uint8_t current_execution_context_get(void)
     return (uint8_t)((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) >> SCB_ICSR_VECTACTIVE_Pos);
 }
 
-/** @brief Check if the provided context is the same as the currently executed one.
- *
- * @param  context Context to check against the current context.
- *
- * @retval true    Active vector priority allows nested critical sections.
- * @retval false   Active vector priority denies nested critical sections.
- */
-static inline bool nested_critical_section_is_allowed_in_this_context(uint8_t context)
-{
-    return context == current_execution_context_get();
-}
-
 static bool critical_section_enter(void)
 {
     uint8_t  counter;
@@ -160,7 +148,7 @@ static void critical_section_exit(void)
     // Operate on local copy of the volatile variable for faster execution.
     counter = m_nested_critical_section_counter;
 
-    // Assert that every exit() call is paired with an enter() call
+    // Assert that every exit() call is paired with a successful enter() call
     assert(counter > 0);
 
     do

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -126,11 +126,12 @@ static bool critical_section_enter(void)
         nrf_802154_critical_section_rsch_enter();
         nrf_802154_lp_timer_critical_section_enter();
         radio_critical_section_enter();
-        __DSB();
-        __ISB();
 
         m_nested_critical_section_counter         = counter;
         m_nested_critical_section_current_context = context;
+
+        __DSB();
+        __ISB();
 
         result = true;
     }
@@ -150,7 +151,7 @@ static void critical_section_exit(void)
     // Operate on local copy of the volatile variable for faster execution.
     counter = m_nested_critical_section_counter;
 
-    // Assert that every exit() call is paired with and enter() call
+    // Assert that every exit() call is paired with an enter() call
     assert(counter > 0);
 
     // Exit critical section only if it is not nested.

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -47,10 +47,10 @@
 
 #include <nrf.h>
 
-#define CMSIS_IRQ_NUM_VECTACTIVE_DIFF                 16            ///< Offset in exception number of external interrupts according to ARM Archuitecture Reference Manual
+#define CMSIS_IRQ_NUM_VECTACTIVE_DIFF 16                           ///< Offset in exception number of external interrupts according to ARM Archuitecture Reference Manual
 
-static volatile uint8_t m_nested_critical_section_counter;          ///< Counter of nested critical sections
-static volatile uint8_t m_nested_critical_section_current_context;  ///< Execution context of the current critical section
+static volatile uint8_t m_nested_critical_section_counter;         ///< Counter of nested critical sections
+static volatile uint8_t m_nested_critical_section_current_context; ///< Execution context of the current critical section
 
 /***************************************************************************************************
  * @section Critical sections management
@@ -180,6 +180,7 @@ static void critical_section_exit(void)
         if (nrf_802154_critical_section_rsch_event_is_pending())
         {
             bool result = critical_section_enter();
+
             assert(result);
             (void)result;
 
@@ -193,7 +194,8 @@ static void critical_section_exit(void)
         {
             retry = false;
         }
-    } while (retry);
+    }
+    while (retry);
 }
 
 /***************************************************************************************************

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -84,8 +84,8 @@ static void radio_critical_section_exit(void)
 
 /** @brief Get the context the code is currently executed from.
  *
- * @return If the code is executed from the main thread, the function returns UINT32_MAX.
- *         Otherwise, external interrupt number is returned.
+ * @return External interrupt number with @ref CMSIS_IRQ_NUM_VECTACTIVE_DIFF offset in case of
+ *         an interrupt context or 0 when the code is executed from the main thread.
  */
 static uint8_t current_execution_context_get(void)
 {

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -146,17 +146,17 @@ static void critical_section_exit(void)
     uint8_t  counter;
     uint32_t interrupt_state = __get_PRIMASK();
 
+    // Assert that the caller has the right to exit the critical section.
+    assert(m_nested_critical_section_current_context == current_execution_context_get());
+
+    // Operate on local copy of the volatile variable for faster execution.
+    counter = m_nested_critical_section_counter;
+
+    // Assert that every exit() call is paired with an enter() call
+    assert(counter > 0);
+
     do
     {
-        // Assert that the caller has the right to exit the critical section.
-        assert(m_nested_critical_section_current_context == current_execution_context_get());
-
-        // Operate on local copy of the volatile variable for faster execution.
-        counter = m_nested_critical_section_counter;
-
-        // Assert that every exit() call is paired with an enter() call
-        assert(counter > 0);
-
         // Exit RSCH critical section with enabled interrupts (it might take some time).
         if (counter == 1)
         {

--- a/src/nrf_802154_critical_section.h
+++ b/src/nrf_802154_critical_section.h
@@ -64,30 +64,6 @@ bool nrf_802154_critical_section_enter(void);
 void nrf_802154_critical_section_exit(void);
 
 /**
- * @brief Function for forcefully entering a critical section in the 802.15.4 driver.
- *
- * With this function, the critical section is entered regardless of whether
- * it has been already entered before.
- *
- * This function is intended to be used by RADIO IRQ handler and RSCH notifications handlers to
- * prevent interrupting of these procedures by FSM requests from higher priority IRQ handlers.
- */
-void nrf_802154_critical_section_forcefully_enter(void);
-
-/**
- * @brief Allows entry to a nested critical section.
- *
- * This function is intended to be used with the notification module to allow processing
- * requests called from the notification context.
- */
-void nrf_802154_critical_section_nesting_allow(void);
-
-/**
- * @brief Denies entry to a nested critical section.
- */
-void nrf_802154_critical_section_nesting_deny(void);
-
-/**
  * @brief Checks if the critical section is nested.
  *
  * @retval true   Critical section is nested.

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -1913,7 +1913,7 @@ void nrf_802154_radio_irq_handler(void)
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_IRQ_HANDLER);
 
     // Prevent interrupting of this handler by requests from higher priority code.
-    nrf_802154_critical_section_forcefully_enter();
+    nrf_802154_critical_section_enter();
 
     if (nrf_radio_int_enable_check(NRF_RADIO_INT_ADDRESS_MASK) &&
         nrf_radio_event_check(NRF_RADIO_EVENT_ADDRESS))

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -1913,7 +1913,9 @@ void nrf_802154_radio_irq_handler(void)
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_IRQ_HANDLER);
 
     // Prevent interrupting of this handler by requests from higher priority code.
-    nrf_802154_critical_section_enter();
+    bool result = nrf_802154_critical_section_enter();
+    assert(result);
+    (void)result;
 
     if (nrf_radio_int_enable_check(NRF_RADIO_INT_ADDRESS_MASK) &&
         nrf_radio_event_check(NRF_RADIO_EVENT_ADDRESS))

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -1914,6 +1914,7 @@ void nrf_802154_radio_irq_handler(void)
 
     // Prevent interrupting of this handler by requests from higher priority code.
     bool result = nrf_802154_critical_section_enter();
+
     assert(result);
     (void)result;
 

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -217,15 +217,15 @@ static inline void all_prec_update(void)
             }
             else if (prev_prio == RSCH_PRIO_IDLE)
             {
-                if (m_approved_prios[RSCH_PREC_HFCLK] == RSCH_PRIO_IDLE)
-                {
-                    nrf_802154_priority_drop_hfclk_stop_terminate();
-                    nrf_802154_clock_hfclk_start();
-                }
-                if (m_approved_prios[RSCH_PREC_RAAL] == RSCH_PRIO_IDLE)
-                {
-                    nrf_raal_continuous_mode_enter();
-                }
+                // If the previously requested priority is IDLE,
+                // both HFCLK and RAAL preconditions should be idle.
+                assert(m_approved_prios[RSCH_PREC_HFCLK] == RSCH_PRIO_IDLE);
+                assert(m_approved_prios[RSCH_PREC_RAAL] == RSCH_PRIO_IDLE);
+
+                nrf_802154_priority_drop_hfclk_stop_terminate();
+                nrf_802154_clock_hfclk_start();
+
+                nrf_raal_continuous_mode_enter();
             }
             else
             {

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -215,7 +215,7 @@ static inline void all_prec_update(void)
                 nrf_raal_continuous_mode_exit();
                 prec_approved_prio_set(RSCH_PREC_RAAL, RSCH_PRIO_IDLE);
             }
-            else
+            else if (prev_prio == RSCH_PRIO_IDLE)
             {
                 if (m_approved_prios[RSCH_PREC_HFCLK] == RSCH_PRIO_IDLE)
                 {
@@ -226,6 +226,10 @@ static inline void all_prec_update(void)
                 {
                     nrf_raal_continuous_mode_enter();
                 }
+            }
+            else
+            {
+                // Intentionally empty
             }
 
             nrf_802154_wifi_coex_prio_request(new_prio);

--- a/src/rsch/nrf_802154_rsch_crit_sect.c
+++ b/src/rsch/nrf_802154_rsch_crit_sect.c
@@ -111,15 +111,9 @@ void nrf_802154_rsch_crit_sect_prio_request(rsch_prio_t prio)
 
 void nrf_802154_rsch_continuous_prio_changed(rsch_prio_t prio)
 {
-    bool crit_sect_success = false;
+    bool crit_sect_success = nrf_802154_critical_section_enter();
 
-    crit_sect_success = nrf_802154_critical_section_enter();
-
-    // If we managed to enter critical section, but there is already a pending event,
-    // it means that the Critical Section module is about to make one more iteration of the
-    // critical section exit procedure. To prevent race in continuous mode priorities notification,
-    // we do not notify directly, but just update the pending event.
-    if (crit_sect_success && rsch_pending_evt_is_none())
+    if (crit_sect_success)
     {
         nrf_802154_rsch_crit_sect_prio_changed(prio);
     }

--- a/src/rsch/nrf_802154_rsch_crit_sect.c
+++ b/src/rsch/nrf_802154_rsch_crit_sect.c
@@ -115,16 +115,13 @@ void nrf_802154_rsch_continuous_prio_changed(rsch_prio_t prio)
 
     if (crit_sect_success)
     {
+        (void)rsch_pending_evt_clear();
         nrf_802154_rsch_crit_sect_prio_changed(prio);
+        nrf_802154_critical_section_exit();
     }
     else
     {
         rsch_pending_evt_set(prio);
-    }
-
-    if (crit_sect_success)
-    {
-        nrf_802154_critical_section_exit();
     }
 }
 

--- a/src/rsch/nrf_802154_rsch_crit_sect.c
+++ b/src/rsch/nrf_802154_rsch_crit_sect.c
@@ -115,6 +115,8 @@ void nrf_802154_rsch_continuous_prio_changed(rsch_prio_t prio)
 
     if (crit_sect_success)
     {
+        // A change of RSCH state occurred and entered the critical section successfully.
+        // The pending event has become obsolete and is irrelevant now.
         (void)rsch_pending_evt_clear();
         nrf_802154_rsch_crit_sect_prio_changed(prio);
         nrf_802154_critical_section_exit();


### PR DESCRIPTION
This PR is a rework of the driver's critical sections in order to support multiprotocol after refactoring of the core module. The most significant design changes of the module are:
* critical section can be nested by code executed from the same context the critical section was originally requested from,
* critical section enter and exit operations are mostly performed atomically, i.e. with interrupts disabled completely,
* critical section cannot be entered forcefully