### PR TITLE
Extend RSCH to support CSMA/CA backoffs

### DIFF
--- a/src/mac_features/nrf_802154_delayed_trx.c
+++ b/src/mac_features/nrf_802154_delayed_trx.c
@@ -201,17 +201,25 @@ static bool dly_op_request(uint32_t         t0,
                            uint32_t         length,
                            rsch_dly_ts_id_t dly_ts_id)
 {
-    bool        result;
-    rsch_prio_t prio;
+    bool                result;
+    rsch_dly_ts_param_t dly_ts_param =
+    {
+        .t0                = t0,
+        .dt                = dt,
+        .length            = length,
+        .prio              = RSCH_PRIO_IDLE,
+        .id                = dly_ts_id,
+        .prec_req_strategy = RSCH_PREC_REQ_STRATEGY_SHORTEST,
+    };
 
     switch (dly_ts_id)
     {
         case RSCH_DLY_TX:
-            prio = RSCH_PRIO_TX;
+            dly_ts_param.prio = RSCH_PRIO_TX;
             break;
 
         case RSCH_DLY_RX:
-            prio = RSCH_PRIO_RX;
+            dly_ts_param.prio = RSCH_PRIO_IDLE_LISTENING;
             break;
 
         default:
@@ -223,12 +231,7 @@ static bool dly_op_request(uint32_t         t0,
     // immediatly and interrupts current function execution.
     dly_op_state_set(dly_ts_id, DELAYED_TRX_OP_STATE_STOPPED, DELAYED_TRX_OP_STATE_PENDING);
 
-    result = nrf_802154_rsch_delayed_timeslot_request(t0,
-                                                      dt,
-                                                      length,
-                                                      prio,
-                                                      dly_ts_id,
-                                                      RSCH_PREC_REQ_MINIMAL);
+    result = nrf_802154_rsch_delayed_timeslot_request(&dly_ts_param);
 
     if (!result)
     {
@@ -490,7 +493,7 @@ void nrf_802154_rsch_delayed_timeslot_started(rsch_dly_ts_id_t dly_ts_id)
 
 bool nrf_802154_delayed_trx_transmit_cancel(void)
 {
-    bool result = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_TX, RSCH_PREC_REQ_MINIMAL);
+    bool result = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_TX);
 
     m_dly_op_state[RSCH_DLY_TX] = DELAYED_TRX_OP_STATE_STOPPED;
 
@@ -499,7 +502,7 @@ bool nrf_802154_delayed_trx_transmit_cancel(void)
 
 bool nrf_802154_delayed_trx_receive_cancel(void)
 {
-    bool result = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_RX, RSCH_PREC_REQ_MINIMAL);
+    bool result = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_RX);
     bool was_running;
 
     nrf_802154_timer_sched_remove(&m_timeout_timer, &was_running);

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -58,11 +58,11 @@ static rsch_prio_t          m_cont_mode_prio;                ///< Continuous mod
 
 typedef struct
 {
-    rsch_prio_t            prio;     ///< Delayed timeslot priority level. If delayed timeslot is not scheduled equal to @ref RSCH_PRIO_IDLE.
-    uint32_t               t0;       ///< Time base of the delayed timeslot trigger time.
-    uint32_t               dt;       ///< Time delta of the delayed timeslot trigger time.
-    nrf_802154_timer_t     timer;    ///< Timer used to trigger delayed timeslot.
-    rsch_dly_ts_prec_req_t prec_req; ///< Delayed timeslot precondition requesting strategy.
+    uint32_t                        t0;                ///< Time base of the delayed timeslot trigger time.
+    uint32_t                        dt;                ///< Time delta of the delayed timeslot trigger time.
+    rsch_prio_t                     prio;              ///< Delayed timeslot priority level. If delayed timeslot is not scheduled equal to @ref RSCH_PRIO_IDLE.
+    nrf_802154_timer_t              timer;             ///< Timer used to trigger delayed timeslot.
+    rsch_dly_ts_prec_req_strategy_t prec_req_strategy; ///< Delayed timeslot precondition requesting strategy.
 } dly_ts_t;
 
 static dly_ts_t m_dly_ts[RSCH_DLY_TS_NUM];
@@ -116,11 +116,11 @@ static inline void mutex_unlock(volatile uint8_t * p_mutex)
 
 /** @brief Check maximal priority level required by any of delayed timeslots at the moment.
  *
- * For delayed timeslots requested with @ref RSCH_PREC_REQ_MINIMAL, in order to meet their timing
- * requirements there is a time window in which radio preconditions should be requested.
+ * For delayed timeslots requested with @ref RSCH_PREC_REQ_STRATEGY_SHORTEST, in order to meet their
+ * timing requirements there is a time window in which radio preconditions should be requested.
  * This function is used to prevent releasing preconditions in this time window.
  *
- * For delayed timeslots requested with @ref RSCH_PREC_REQ_CONSTANT, this function prevents
+ * For delayed timeslots requested with @ref RSCH_PREC_REQ_STRATEGY_MANUAL, this function prevents
  * releasing their preconditions as long as they are active (i.e. not cancelled explicitly).
  *
  * @return  Maximal priority level required by delayed timeslots.
@@ -134,18 +134,19 @@ static rsch_prio_t max_prio_for_delayed_timeslot_get(void)
 
     for (uint32_t i = 0; i < RSCH_DLY_TS_NUM; i++)
     {
-        dly_ts_t * p_dly_ts      = &m_dly_ts[i];
-        bool       active_dly_ts = p_dly_ts->prio > result;
-        uint32_t   t0            = p_dly_ts->t0;
-        uint32_t   dt            = p_dly_ts->dt - PREC_RAMP_UP_TIME -
-                                   nrf_802154_timer_sched_granularity_get();
+        dly_ts_t  * p_dly_ts    = &m_dly_ts[i];
+        rsch_prio_t dly_ts_prio = p_dly_ts->prio;
+        uint32_t    t0          = p_dly_ts->t0;
+        uint32_t    dt          = p_dly_ts->dt - PREC_RAMP_UP_TIME -
+                                  nrf_802154_timer_sched_granularity_get();
 
-        if (p_dly_ts->prec_req == RSCH_PREC_REQ_MINIMAL)
+        if ((p_dly_ts->prec_req_strategy == RSCH_PREC_REQ_STRATEGY_SHORTEST) &&
+            nrf_802154_timer_sched_time_is_in_future(now, t0, dt))
         {
-            active_dly_ts = active_dly_ts && !nrf_802154_timer_sched_time_is_in_future(now, t0, dt);
+            dly_ts_prio = RSCH_PRIO_IDLE;
         }
 
-        result = active_dly_ts ? p_dly_ts->prio : result;
+        result = dly_ts_prio > result ? dly_ts_prio : result;
     }
 
     nrf_802154_log_exit(max_prio_for_delayed_timeslot_get, 2);
@@ -339,7 +340,7 @@ static void delayed_timeslot_start(void * p_context)
     nrf_802154_rsch_delayed_timeslot_started(dly_ts_id);
 
     // Drop preconditions immediately if minimal request strategy has been selected
-    if (p_dly_ts->prec_req == RSCH_PREC_REQ_MINIMAL)
+    if (p_dly_ts->prec_req_strategy == RSCH_PREC_REQ_STRATEGY_SHORTEST)
     {
         p_dly_ts->prio = RSCH_PRIO_IDLE;
         all_prec_update();
@@ -435,48 +436,43 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us)
     return nrf_raal_timeslot_request(length_us);
 }
 
-bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
-                                              uint32_t               dt,
-                                              uint32_t               length,
-                                              rsch_prio_t            prio,
-                                              rsch_dly_ts_id_t       dly_ts_id,
-                                              rsch_dly_ts_prec_req_t dly_ts_prec_req)
+bool nrf_802154_rsch_delayed_timeslot_request(rsch_dly_ts_param_t * p_dly_ts_param)
 {
-    (void)length;
+    (void)p_dly_ts_param->length;
 
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_RSCH_DELAYED_TIMESLOT_REQ);
-    assert(dly_ts_id < RSCH_DLY_TS_NUM);
+    assert(p_dly_ts_param->id < RSCH_DLY_TS_NUM);
 
-    dly_ts_t * p_dly_ts = &m_dly_ts[dly_ts_id];
+    dly_ts_t * p_dly_ts = &m_dly_ts[p_dly_ts_param->id];
     uint32_t   now      = nrf_802154_timer_sched_time_get();
-    uint32_t   req_dt   = dt - PREC_RAMP_UP_TIME;
+    uint32_t   req_dt   = p_dly_ts_param->dt - PREC_RAMP_UP_TIME;
     bool       result   = true;
 
     assert(!nrf_802154_timer_sched_is_running(&p_dly_ts->timer));
     assert(p_dly_ts->prio == RSCH_PRIO_IDLE);
-    assert(prio != RSCH_PRIO_IDLE);
+    assert(p_dly_ts_param->prio != RSCH_PRIO_IDLE);
 
     // There is enough time for preconditions ramp-up no matter their current state.
-    if (nrf_802154_timer_sched_time_is_in_future(now, t0, req_dt))
+    if (nrf_802154_timer_sched_time_is_in_future(now, p_dly_ts_param->t0, req_dt))
     {
-        p_dly_ts->prio     = prio;
-        p_dly_ts->t0       = t0;
-        p_dly_ts->dt       = dt;
-        p_dly_ts->prec_req = dly_ts_prec_req;
+        p_dly_ts->prio              = p_dly_ts_param->prio;
+        p_dly_ts->t0                = p_dly_ts_param->t0;
+        p_dly_ts->dt                = p_dly_ts_param->dt;
+        p_dly_ts->prec_req_strategy = p_dly_ts_param->prec_req_strategy;
 
-        p_dly_ts->timer.t0        = t0;
-        p_dly_ts->timer.p_context = (void *)dly_ts_id;
+        p_dly_ts->timer.t0        = p_dly_ts_param->t0;
+        p_dly_ts->timer.p_context = (void *)p_dly_ts_param->id;
 
-        switch (dly_ts_prec_req)
+        switch (p_dly_ts_param->prec_req_strategy)
         {
-            case RSCH_PREC_REQ_MINIMAL:
+            case RSCH_PREC_REQ_STRATEGY_SHORTEST:
                 p_dly_ts->timer.dt       = req_dt;
                 p_dly_ts->timer.callback = delayed_timeslot_prec_request;
                 nrf_802154_timer_sched_add(&p_dly_ts->timer, false);
                 break;
 
-            case RSCH_PREC_REQ_CONSTANT:
-                p_dly_ts->timer.dt       = dt;
+            case RSCH_PREC_REQ_STRATEGY_MANUAL:
+                p_dly_ts->timer.dt       = p_dly_ts_param->dt;
                 p_dly_ts->timer.callback = delayed_timeslot_start;
                 all_prec_update();
                 nrf_802154_timer_sched_add(&p_dly_ts->timer, false);
@@ -490,17 +486,17 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
     }
     // There is not enough time to perform full precondition ramp-up. Try with the currently approved preconditions
     else if (requested_prio_lvl_is_at_least(RSCH_PRIO_IDLE_LISTENING) &&
-             nrf_802154_timer_sched_time_is_in_future(now, t0, dt))
+             nrf_802154_timer_sched_time_is_in_future(now, p_dly_ts_param->t0, p_dly_ts_param->dt))
     {
-        p_dly_ts->prio     = prio;
-        p_dly_ts->t0       = t0;
-        p_dly_ts->dt       = dt;
-        p_dly_ts->prec_req = dly_ts_prec_req;
+        p_dly_ts->prio              = p_dly_ts_param->prio;
+        p_dly_ts->t0                = p_dly_ts_param->t0;
+        p_dly_ts->dt                = p_dly_ts_param->dt;
+        p_dly_ts->prec_req_strategy = p_dly_ts_param->prec_req_strategy;
 
-        p_dly_ts->timer.t0        = t0;
-        p_dly_ts->timer.dt        = dt;
+        p_dly_ts->timer.t0        = p_dly_ts_param->t0;
+        p_dly_ts->timer.dt        = p_dly_ts_param->dt;
         p_dly_ts->timer.callback  = delayed_timeslot_start;
-        p_dly_ts->timer.p_context = (void *)dly_ts_id;
+        p_dly_ts->timer.p_context = (void *)p_dly_ts_param->id;
 
         all_prec_update();
 
@@ -517,8 +513,7 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
     return result;
 }
 
-bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t       dly_ts_id,
-                                             rsch_dly_ts_prec_req_t dly_ts_prec_req)
+bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id)
 {
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_RSCH_DELAYED_TIMESLOT_CANCEL);
     assert(dly_ts_id < RSCH_DLY_TS_NUM);
@@ -533,13 +528,13 @@ bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t       dly_ts_id,
     all_prec_update();
     notify_core();
 
-    switch (dly_ts_prec_req)
+    switch (p_dly_ts->prec_req_strategy)
     {
-        case RSCH_PREC_REQ_MINIMAL:
+        case RSCH_PREC_REQ_STRATEGY_SHORTEST:
             result = was_running;
             break;
 
-        case RSCH_PREC_REQ_CONSTANT:
+        case RSCH_PREC_REQ_STRATEGY_MANUAL:
             result = true;
             break;
 

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -436,10 +436,8 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us)
     return nrf_raal_timeslot_request(length_us);
 }
 
-bool nrf_802154_rsch_delayed_timeslot_request(rsch_dly_ts_param_t * p_dly_ts_param)
+bool nrf_802154_rsch_delayed_timeslot_request(const rsch_dly_ts_param_t * p_dly_ts_param)
 {
-    (void)p_dly_ts_param->length;
-
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_RSCH_DELAYED_TIMESLOT_REQ);
     assert(p_dly_ts_param->id < RSCH_DLY_TS_NUM);
 

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -338,10 +338,13 @@ static void delayed_timeslot_start(void * p_context)
 
     nrf_802154_rsch_delayed_timeslot_started(dly_ts_id);
 
-    p_dly_ts->prio = RSCH_PRIO_IDLE;
-
-    all_prec_update();
-    notify_core();
+    // Drop preconditions immediately if minimal request strategy has been selected
+    if (p_dly_ts->prec_req == RSCH_PREC_REQ_MINIMAL)
+    {
+        p_dly_ts->prio = RSCH_PRIO_IDLE;
+        all_prec_update();
+        notify_core();
+    }
 
     nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_RSCH_TIMER_DELAYED_START);
 }

--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -58,10 +58,11 @@ static rsch_prio_t          m_cont_mode_prio;                ///< Continuous mod
 
 typedef struct
 {
-    rsch_prio_t        prio;  ///< Delayed timeslot priority level. If delayed timeslot is not scheduled equal to @ref RSCH_PRIO_IDLE.
-    uint32_t           t0;    ///< Time base of the delayed timeslot trigger time.
-    uint32_t           dt;    ///< Time delta of the delayed timeslot trigger time.
-    nrf_802154_timer_t timer; ///< Timer used to trigger delayed timeslot.
+    rsch_prio_t            prio;     ///< Delayed timeslot priority level. If delayed timeslot is not scheduled equal to @ref RSCH_PRIO_IDLE.
+    uint32_t               t0;       ///< Time base of the delayed timeslot trigger time.
+    uint32_t               dt;       ///< Time delta of the delayed timeslot trigger time.
+    nrf_802154_timer_t     timer;    ///< Timer used to trigger delayed timeslot.
+    rsch_dly_ts_prec_req_t prec_req; ///< Delayed timeslot precondition requesting strategy.
 } dly_ts_t;
 
 static dly_ts_t m_dly_ts[RSCH_DLY_TS_NUM];
@@ -115,9 +116,12 @@ static inline void mutex_unlock(volatile uint8_t * p_mutex)
 
 /** @brief Check maximal priority level required by any of delayed timeslots at the moment.
  *
- * To meet delayed timeslot timing requirements there is a time window in which radio
- * preconditions should be requested. This function is used to prevent releasing preconditions
- * in this time window.
+ * For delayed timeslots requested with @ref RSCH_PREC_REQ_MINIMAL, in order to meet their timing
+ * requirements there is a time window in which radio preconditions should be requested.
+ * This function is used to prevent releasing preconditions in this time window.
+ *
+ * For delayed timeslots requested with @ref RSCH_PREC_REQ_CONSTANT, this function prevents
+ * releasing their preconditions as long as they are active (i.e. not cancelled explicitly).
  *
  * @return  Maximal priority level required by delayed timeslots.
  */
@@ -130,15 +134,18 @@ static rsch_prio_t max_prio_for_delayed_timeslot_get(void)
 
     for (uint32_t i = 0; i < RSCH_DLY_TS_NUM; i++)
     {
-        dly_ts_t * p_dly_ts = &m_dly_ts[i];
-        uint32_t   t0       = p_dly_ts->t0;
-        uint32_t   dt       = p_dly_ts->dt - PREC_RAMP_UP_TIME -
-                              nrf_802154_timer_sched_granularity_get();
+        dly_ts_t * p_dly_ts      = &m_dly_ts[i];
+        bool       active_dly_ts = p_dly_ts->prio > result;
+        uint32_t   t0            = p_dly_ts->t0;
+        uint32_t   dt            = p_dly_ts->dt - PREC_RAMP_UP_TIME -
+                                   nrf_802154_timer_sched_granularity_get();
 
-        if ((p_dly_ts->prio > result) && !nrf_802154_timer_sched_time_is_in_future(now, t0, dt))
+        if (p_dly_ts->prec_req == RSCH_PREC_REQ_MINIMAL)
         {
-            result = p_dly_ts->prio;
+            active_dly_ts = active_dly_ts && !nrf_802154_timer_sched_time_is_in_future(now, t0, dt);
         }
+
+        result = active_dly_ts ? p_dly_ts->prio : result;
     }
 
     nrf_802154_log_exit(max_prio_for_delayed_timeslot_get, 2);
@@ -385,6 +392,7 @@ void nrf_802154_rsch_init(void)
     {
         m_approved_prios[i] = RSCH_PRIO_IDLE;
     }
+
     nrf_802154_wifi_coex_init();
 }
 
@@ -424,11 +432,12 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us)
     return nrf_raal_timeslot_request(length_us);
 }
 
-bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
-                                              uint32_t         dt,
-                                              uint32_t         length,
-                                              rsch_prio_t      prio,
-                                              rsch_dly_ts_id_t dly_ts_id)
+bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
+                                              uint32_t               dt,
+                                              uint32_t               length,
+                                              rsch_prio_t            prio,
+                                              rsch_dly_ts_id_t       dly_ts_id,
+                                              rsch_dly_ts_prec_req_t dly_ts_prec_req)
 {
     (void)length;
 
@@ -438,33 +447,52 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
     dly_ts_t * p_dly_ts = &m_dly_ts[dly_ts_id];
     uint32_t   now      = nrf_802154_timer_sched_time_get();
     uint32_t   req_dt   = dt - PREC_RAMP_UP_TIME;
-    bool       result;
+    bool       result   = true;
 
     assert(!nrf_802154_timer_sched_is_running(&p_dly_ts->timer));
     assert(p_dly_ts->prio == RSCH_PRIO_IDLE);
     assert(prio != RSCH_PRIO_IDLE);
 
+    // There is enough time for preconditions ramp-up no matter their current state.
     if (nrf_802154_timer_sched_time_is_in_future(now, t0, req_dt))
     {
-        p_dly_ts->prio = prio;
-        p_dly_ts->t0   = t0;
-        p_dly_ts->dt   = dt;
+        p_dly_ts->prio     = prio;
+        p_dly_ts->t0       = t0;
+        p_dly_ts->dt       = dt;
+        p_dly_ts->prec_req = dly_ts_prec_req;
 
         p_dly_ts->timer.t0        = t0;
-        p_dly_ts->timer.dt        = req_dt;
-        p_dly_ts->timer.callback  = delayed_timeslot_prec_request;
         p_dly_ts->timer.p_context = (void *)dly_ts_id;
 
-        nrf_802154_timer_sched_add(&p_dly_ts->timer, false);
+        switch (dly_ts_prec_req)
+        {
+            case RSCH_PREC_REQ_MINIMAL:
+                p_dly_ts->timer.dt       = req_dt;
+                p_dly_ts->timer.callback = delayed_timeslot_prec_request;
+                nrf_802154_timer_sched_add(&p_dly_ts->timer, false);
+                break;
 
-        result = true;
+            case RSCH_PREC_REQ_CONSTANT:
+                p_dly_ts->timer.dt       = dt;
+                p_dly_ts->timer.callback = delayed_timeslot_start;
+                all_prec_update();
+                nrf_802154_timer_sched_add(&p_dly_ts->timer, false);
+                break;
+
+            default:
+                result = false;
+                assert(false);
+                break;
+        }
     }
+    // There is not enough time to perform full precondition ramp-up. Try with the currently approved preconditions
     else if (requested_prio_lvl_is_at_least(RSCH_PRIO_IDLE_LISTENING) &&
              nrf_802154_timer_sched_time_is_in_future(now, t0, dt))
     {
-        p_dly_ts->prio = prio;
-        p_dly_ts->t0   = t0;
-        p_dly_ts->dt   = dt;
+        p_dly_ts->prio     = prio;
+        p_dly_ts->t0       = t0;
+        p_dly_ts->dt       = dt;
+        p_dly_ts->prec_req = dly_ts_prec_req;
 
         p_dly_ts->timer.t0        = t0;
         p_dly_ts->timer.dt        = dt;
@@ -474,9 +502,8 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
         all_prec_update();
 
         nrf_802154_timer_sched_add(&p_dly_ts->timer, true);
-
-        result = true;
     }
+    // The requested time is in the past.
     else
     {
         result = false;
@@ -487,7 +514,8 @@ bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
     return result;
 }
 
-bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id)
+bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t       dly_ts_id,
+                                             rsch_dly_ts_prec_req_t dly_ts_prec_req)
 {
     nrf_802154_log(EVENT_TRACE_ENTER, FUNCTION_RSCH_DELAYED_TIMESLOT_CANCEL);
     assert(dly_ts_id < RSCH_DLY_TS_NUM);
@@ -502,7 +530,19 @@ bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id)
     all_prec_update();
     notify_core();
 
-    result = was_running;
+    switch (dly_ts_prec_req)
+    {
+        case RSCH_PREC_REQ_MINIMAL:
+            result = was_running;
+            break;
+
+        case RSCH_PREC_REQ_CONSTANT:
+            result = true;
+            break;
+
+        default:
+            assert(false);
+    }
 
     nrf_802154_log(EVENT_TRACE_EXIT, FUNCTION_RSCH_DELAYED_TIMESLOT_CANCEL);
 

--- a/src/rsch/nrf_802154_rsch.h
+++ b/src/rsch/nrf_802154_rsch.h
@@ -100,9 +100,22 @@ typedef enum
  */
 typedef enum
 {
-    RSCH_PREC_REQ_CONSTANT, ///< Preconditions requested immediately and released only by @ref nrf_802154_rsch_delayed_timeslot_cancel call.
-    RSCH_PREC_REQ_MINIMAL,  ///< Preconditions requested as late as possible and released as soon as possible.
-} rsch_dly_ts_prec_req_t;
+    RSCH_PREC_REQ_STRATEGY_MANUAL,   ///< Preconditions requested immediately and released only by @ref nrf_802154_rsch_delayed_timeslot_cancel call.
+    RSCH_PREC_REQ_STRATEGY_SHORTEST, ///< Preconditions requested as late as possible and released as soon as possible.
+} rsch_dly_ts_prec_req_strategy_t;
+
+/**
+ * @brief Structure that holds parameters of a delayed timeslot request.
+ */
+typedef struct
+{
+    uint32_t                        t0;                ///< Base time of the timestamp of the timeslot start, in microseconds.
+    uint32_t                        dt;                ///< Time delta between @p t0 and the timestamp of the timeslot start, in microseconds.
+    uint32_t                        length;            ///< Requested radio timeslot length, in microseconds.
+    rsch_prio_t                     prio;              ///< Priority level required for the delayed timeslot.
+    rsch_dly_ts_id_t                id;                ///< Type of the requested timeslot.
+    rsch_dly_ts_prec_req_strategy_t prec_req_strategy; ///< Precondition request strategy.
+} rsch_dly_ts_param_t;
 
 /**
  * @brief Initializes Radio Scheduler.
@@ -172,34 +185,22 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us);
  *
  * @note The time parameters use the same units that are used in the Timer Scheduler module.
  *
- * @param[in]  t0               Base time of the timestamp of the timeslot start, in microseconds.
- * @param[in]  dt               Time delta between @p t0 and the timestamp of the timeslot start, in microseconds.
- * @param[in]  length           Requested radio timeslot length, in microseconds.
- * @param[in]  prio             Priority level required for the delayed timeslot.
- * @param[in]  dly_ts_id        Type of the requested timeslot.
- * @param[in]  dly_ts_prec_req  Precondition request strategy.
+ * @param[in]  p_dly_ts_param  Parameters of the requested delayed timeslot.
  *
  * @retval true   Requested timeslot has been scheduled.
  * @retval false  Requested timeslot cannot be scheduled and will not be granted.
  */
-bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
-                                              uint32_t               dt,
-                                              uint32_t               length,
-                                              rsch_prio_t            prio,
-                                              rsch_dly_ts_id_t       dly_ts_id,
-                                              rsch_dly_ts_prec_req_t dly_ts_prec_req);
+bool nrf_802154_rsch_delayed_timeslot_request(rsch_dly_ts_param_t * p_dly_ts_param);
 
 /**
  * @brief Cancels a requested future timeslot.
  *
- * @param[in] dly_ts_id        Type of the requested timeslot.
- * @param[in] dly_ts_prec_req  Precondition request strategy of the requested timeslot.
+ * @param[in] dly_ts_id  Type of the requested timeslot.
  *
  * @retval true     Scheduled timeslot has been cancelled.
  * @retval false    No scheduled timeslot has been requested (nothing to cancel).
  */
-bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t       dly_ts_id,
-                                             rsch_dly_ts_prec_req_t dly_ts_prec_req);
+bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id);
 
 /**
  * @brief Checks if there is a pending timeslot request.

--- a/src/rsch/nrf_802154_rsch.h
+++ b/src/rsch/nrf_802154_rsch.h
@@ -90,9 +90,19 @@ typedef enum
 {
     RSCH_DLY_TX,     ///< Timeslot for delayed TX operation.
     RSCH_DLY_RX,     ///< Timeslot for delayed RX operation.
+    RSCH_DLY_CSMACA, ///< Timeslot for CSMA/CA operation.
 
     RSCH_DLY_TS_NUM, ///< Number of delayed timeslots.
 } rsch_dly_ts_id_t;
+
+/**
+ * @brief Enumeration of the precondition requesting strategies.
+ */
+typedef enum
+{
+    RSCH_PREC_REQ_CONSTANT, ///< Preconditions requested immediately and released only by @ref nrf_802154_rsch_delayed_timeslot_cancel call.
+    RSCH_PREC_REQ_MINIMAL,  ///< Preconditions requested as late as possible and released as soon as possible.
+} rsch_dly_ts_prec_req_t;
 
 /**
  * @brief Initializes Radio Scheduler.
@@ -162,30 +172,34 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us);
  *
  * @note The time parameters use the same units that are used in the Timer Scheduler module.
  *
- * @param[in]  t0      Base time of the timestamp of the timeslot start, in microseconds.
- * @param[in]  dt      Time delta between @p t0 and the timestamp of the timeslot start, in microseconds.
- * @param[in]  length  Requested radio timeslot length, in microseconds.
- * @param[in]  prio    Priority level required for the delayed timeslot.
- * @param[in]  dly_ts  Type of the requested timeslot.
+ * @param[in]  t0               Base time of the timestamp of the timeslot start, in microseconds.
+ * @param[in]  dt               Time delta between @p t0 and the timestamp of the timeslot start, in microseconds.
+ * @param[in]  length           Requested radio timeslot length, in microseconds.
+ * @param[in]  prio             Priority level required for the delayed timeslot.
+ * @param[in]  dly_ts_id        Type of the requested timeslot.
+ * @param[in]  dly_ts_prec_req  Precondition request strategy.
  *
  * @retval true   Requested timeslot has been scheduled.
  * @retval false  Requested timeslot cannot be scheduled and will not be granted.
  */
-bool nrf_802154_rsch_delayed_timeslot_request(uint32_t         t0,
-                                              uint32_t         dt,
-                                              uint32_t         length,
-                                              rsch_prio_t      prio,
-                                              rsch_dly_ts_id_t dly_ts);
+bool nrf_802154_rsch_delayed_timeslot_request(uint32_t               t0,
+                                              uint32_t               dt,
+                                              uint32_t               length,
+                                              rsch_prio_t            prio,
+                                              rsch_dly_ts_id_t       dly_ts_id,
+                                              rsch_dly_ts_prec_req_t dly_ts_prec_req);
 
 /**
  * @brief Cancels a requested future timeslot.
  *
- * @param[in] dly_ts_id     Type of the requested timeslot.
+ * @param[in] dly_ts_id        Type of the requested timeslot.
+ * @param[in] dly_ts_prec_req  Precondition request strategy of the requested timeslot.
  *
  * @retval true     Scheduled timeslot has been cancelled.
  * @retval false    No scheduled timeslot has been requested (nothing to cancel).
  */
-bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id);
+bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t       dly_ts_id,
+                                             rsch_dly_ts_prec_req_t dly_ts_prec_req);
 
 /**
  * @brief Checks if there is a pending timeslot request.

--- a/src/rsch/nrf_802154_rsch.h
+++ b/src/rsch/nrf_802154_rsch.h
@@ -190,7 +190,7 @@ bool nrf_802154_rsch_timeslot_request(uint32_t length_us);
  * @retval true   Requested timeslot has been scheduled.
  * @retval false  Requested timeslot cannot be scheduled and will not be granted.
  */
-bool nrf_802154_rsch_delayed_timeslot_request(rsch_dly_ts_param_t * p_dly_ts_param);
+bool nrf_802154_rsch_delayed_timeslot_request(const rsch_dly_ts_param_t * p_dly_ts_param);
 
 /**
  * @brief Cancels a requested future timeslot.


### PR DESCRIPTION
Exising implementation of delayed operations requests their preconditions as late as possible. This commit extends RSCH to support delayed timeslots with preconditions requested immediately and released with an explicit call only.