### PR TITLE
[build] fix build error under GCC4

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -174,36 +174,44 @@ static volatile radio_state_t m_state; ///< State of the radio driver.
 
 /// Common parameters for the FAL handling.
 static const nrf_802154_fal_event_t m_deactivate_on_disable =
-{.type         = NRF_802154_FAL_EVENT_TYPE_GENERIC,
- .override_ppi =
-     false,
- .event.generic.register_address =
-     ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_DISABLED)};
+{
+    .type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
+    .override_ppi                   = false,
+    .event.generic.register_address =
+        ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_DISABLED)
+};
 
 static const nrf_802154_fal_event_t m_activate_rx_cc0 =
-{.type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
- .override_ppi                 = false,
- .event.timer.p_timer_instance =
-     NRF_802154_TIMER_INSTANCE,
- .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
- .event.timer.counter_value        =
-     RX_RAMP_UP_TIME};
+{
+    .type         = NRF_802154_FAL_EVENT_TYPE_TIMER,
+    .override_ppi = false,
+    .event.timer  =
+    {
+        .p_timer_instance     = NRF_802154_TIMER_INSTANCE,
+        .counter_value        = RX_RAMP_UP_TIME,
+        .compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
+    },
+};
 
 static const nrf_802154_fal_event_t m_activate_tx_cc0 =
-{.type                         = NRF_802154_FAL_EVENT_TYPE_TIMER,
- .override_ppi                 = false,
- .event.timer.p_timer_instance =
-     NRF_802154_TIMER_INSTANCE,
- .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
- .event.timer.counter_value        =
-     TX_RAMP_UP_TIME};
+{
+    .type         = NRF_802154_FAL_EVENT_TYPE_TIMER,
+    .override_ppi = false,
+    .event.timer  =
+    {
+        .p_timer_instance     = NRF_802154_TIMER_INSTANCE,
+        .counter_value        = TX_RAMP_UP_TIME,
+        .compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
+    },
+};
 
 static const nrf_802154_fal_event_t m_ccaidle =
-{.type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
- .override_ppi                   = true,
- .ppi_ch_id                      = PPI_CCAIDLE_FEM,
- .event.generic.register_address =
-     ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_CCAIDLE)};
+{
+    .type                           = NRF_802154_FAL_EVENT_TYPE_GENERIC,
+    .override_ppi                   = true,
+    .ppi_ch_id                      = PPI_CCAIDLE_FEM,
+    .event.generic.register_address = ((uint32_t)NRF_RADIO_BASE + (uint32_t)NRF_RADIO_EVENT_CCAIDLE)
+};
 
 typedef struct
 {


### PR DESCRIPTION
This PR fixes build error under GCC4 and also adjust funky formating.

```
/home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.c:188:2: error: missing initializer for field 'counter_value' of 'struct <anonymous>' [-Werror=missing-field-initializers]
  .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
  ^
In file included from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154.h:49:0,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_notification.h:37,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.h:43,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.c:37:
/home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_protocol_api.h:86:30: note: 'counter_value' declared here
             uint32_t         counter_value;        /* Timer value when the radio activity starts. */
                              ^
/home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.c:197:2: error: missing initializer for field 'counter_value' of 'struct <anonymous>' [-Werror=missing-field-initializers]
  .event.timer.compare_channel_mask = ((1 << NRF_TIMER_CC_CHANNEL0) | (1 << NRF_TIMER_CC_CHANNEL2)),
  ^
In file included from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154.h:49:0,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_notification.h:37,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.h:43,
                 from /home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.c:37:
/home/travis/build/LuDuda/openthread/examples/../third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_protocol_api.h:86:30: note: 'counter_value' declared here
             uint32_t         counter_value;        /* Timer value when the radio activity starts. */
                              ^
```