### PR TITLE
Modify Coex TX request mode behaviour

### DIFF
--- a/src/rsch/nrf_802154_rsch.c
+++ b/src/rsch/nrf_802154_rsch.c
@@ -581,6 +581,25 @@ bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id)
     return result;
 }
 
+bool nrf_802154_rsch_delayed_timeslot_priority_update(rsch_dly_ts_id_t dly_ts_id,
+                                                      rsch_prio_t      dly_ts_prio)
+{
+    assert(dly_ts_id < RSCH_DLY_TS_NUM);
+
+    dly_ts_t * p_dly_ts = &m_dly_ts[dly_ts_id];
+
+    // Do not modify inactive timeslot
+    if (p_dly_ts->param.prio == RSCH_PRIO_IDLE)
+    {
+        return false;
+    }
+    else
+    {
+        p_dly_ts->param.prio = dly_ts_prio;
+        return true;
+    }
+}
+
 bool nrf_802154_rsch_timeslot_is_requested(void)
 {
     bool result = false;

--- a/src/rsch/nrf_802154_rsch.h
+++ b/src/rsch/nrf_802154_rsch.h
@@ -219,6 +219,18 @@ bool nrf_802154_rsch_delayed_timeslot_request(const rsch_dly_ts_param_t * p_dly_
 bool nrf_802154_rsch_delayed_timeslot_cancel(rsch_dly_ts_id_t dly_ts_id);
 
 /**
+ * @brief Updates priority of a requested delayed timeslot.
+ *
+ * @param[in] dly_ts_id    ID of the requested timeslot.
+ * @param[in] dly_ts_prio  Priority to be assigned to the requested timeslot.
+ *
+ * @retval true     Scheduled timeslot's priority has been updated.
+ * @retval false    Priority of the specified timeslot could not be updated.
+ */
+bool nrf_802154_rsch_delayed_timeslot_priority_update(rsch_dly_ts_id_t dly_ts_id,
+                                                      rsch_prio_t      dly_ts_prio);
+
+/**
  * @brief Checks if there is a pending timeslot request.
  *
  * @note The delayed timeslot is considered requested once its preconditions are requested


### PR DESCRIPTION
This patch introduces RSCH API for modifying priority of a requested delayed timeslot. The new API makes it possible to leverage priority of a relaxed delayed timeslot scheduled for CSMA/CA operation, which in turn allows to keep preconditions requested throughout the whole CSMA/CA operation, starting with the first transmission attempt. Priority is not leveraged immediately by the new API call, but takes effect once `all_prec_update` function is called, e.g. due to a core operation.