### PR TITLE
Clear PPI registers after Ack transmission

### DIFF
--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -2175,6 +2175,8 @@ static void txack_finish(void)
      * stopped now, and there is no PPIs starting it automatically by the hardware.
      */
     nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
+    nrf_ppi_channel_endpoint_setup(PPI_TIMER_TX_ACK, 0, 0);
+    nrf_ppi_fork_endpoint_setup(PPI_TIMER_TX_ACK, 0);
 
     nrf_radio_shorts_set(SHORTS_IDLE);
 


### PR DESCRIPTION
Transmissions of frames with CCA and Ack Request result in a PPI channel, shared between the Frontend Module and the Ack timer, not being cleared after an Ack operation. It makes it impossible for the FEM module to use the PPI channel efficiently and causes the PA pin not to be driven at all in some cases. This patch fixes the bug.