### PR TITLE
Implement antenna diversity module

### DIFF
--- a/nRF-IEEE-802.15.4-radio-driver.packsc
+++ b/nRF-IEEE-802.15.4-radio-driver.packsc
@@ -7,6 +7,7 @@
         ],
         "_headers": [
             "src/nrf_802154.h",
+            "src/nrf_802154_ant_div.h",
             "src/nrf_802154_core_hooks.h",
             "src/nrf_802154_critical_section.h",
             "src/nrf_802154_debug.h",
@@ -45,6 +46,7 @@
                 ],
                 "_files": [
                     "src/nrf_802154.c",
+                    "src/nrf_802154_ant_div.c",
                     "src/nrf_802154_core.c",
                     "src/nrf_802154_core_hooks.c",
                     "src/nrf_802154_critical_section.c",
@@ -96,6 +98,7 @@
                 ],
                 "_files": [
                     "src/nrf_802154.c",
+                    "src/nrf_802154_ant_div.c",
                     "src/nrf_802154_core.c",
                     "src/nrf_802154_core_hooks.c",
                     "src/nrf_802154_critical_section.c",
@@ -144,6 +147,7 @@
                 ],
                 "_files": [
                     "src/nrf_802154.c",
+                    "src/nrf_802154_ant_div.c",
                     "src/nrf_802154_core.c",
                     "src/nrf_802154_core_hooks.c",
                     "src/nrf_802154_critical_section.c",
@@ -460,6 +464,14 @@
         "_description": "This option enables CLI.",
         "_defines": [
             "ENABLE_CLI"
+        ]
+    },
+
+    "ant_div": {
+        "_class": "nRF_drv_radio_802_15_4",
+        "_description": "This option enables antenna diversity.",
+        "_defines": [
+            "ENABLE_ANT_DIV"
         ]
     },
 

--- a/src/nrf_802154_ant_div.c
+++ b/src/nrf_802154_ant_div.c
@@ -1,0 +1,111 @@
+/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @file
+ *   This file implements the 802.15.4 antenna diversity module.
+ *
+ */
+#include <assert.h>
+
+#include "nrf_802154_ant_div.h"
+#include "nrf_error.h"
+#include "nrf_gpio.h"
+
+#ifdef ENABLE_ANT_DIV
+
+static nrf_802154_ant_div_config_t m_ant_div_config =      /**< Antenna Diversity configuration */
+{
+    .ant_sel_pin = NRF_ANT_DIV_ANT_SEL_DEFAULT_PIN
+};
+
+int32_t nrf_802154_ant_div_init()
+{
+    nrf_gpio_cfg_output(m_ant_div_config.ant_sel_pin);
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+{
+    assert(p_ant_div_config != NULL);
+    m_ant_div_config = *p_ant_div_config;
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+{
+    assert(p_ant_div_config != NULL);
+    *p_ant_div_config = m_ant_div_config;
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna)
+{
+    nrf_gpio_pin_write(m_ant_div_config.ant_sel_pin, antenna);
+    return NRF_SUCCESS;
+}
+
+int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna)
+{
+    *antenna = (NRF_GPIO->OUT >> m_ant_div_config.ant_sel_pin) & 0x01;
+    return NRF_SUCCESS;
+}
+#else //ENABLE_ANT_DIV
+
+int32_t nrf_802154_ant_div_init()
+{
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+{
+    (void)p_ant_div_config;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+{
+    (void)p_ant_div_config;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna)
+{
+    (void)antenna;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna)
+{
+    (void)antenna;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+#endif //ENABLE_ANT_DIV

--- a/src/nrf_802154_ant_div.c
+++ b/src/nrf_802154_ant_div.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+/* Copyright (c) 2019, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,76 +36,55 @@
 #include <assert.h>
 
 #include "nrf_802154_ant_div.h"
-#include "nrf_error.h"
 #include "nrf_gpio.h"
 
 #ifdef ENABLE_ANT_DIV
 
-static nrf_802154_ant_div_config_t m_ant_div_config =      /**< Antenna Diversity configuration */
+static nrf_802154_ant_div_config_t m_ant_div_config = /**< Antenna Diversity configuration */
 {
-    .ant_sel_pin = NRF_ANT_DIV_ANT_SEL_DEFAULT_PIN
+    .ant_sel_pin = NRF_802154_ANT_DIV_ANT_SEL_DEFAULT_PIN
 };
 
-int32_t nrf_802154_ant_div_init()
+uint32_t nrf_802154_ant_div_init(void)
 {
     nrf_gpio_cfg_output(m_ant_div_config.ant_sel_pin);
     return NRF_SUCCESS;
 }
 
-int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+uint32_t nrf_802154_ant_div_config_set(const nrf_802154_ant_div_config_t * p_ant_div_config)
 {
     assert(p_ant_div_config != NULL);
     m_ant_div_config = *p_ant_div_config;
     return NRF_SUCCESS;
 }
 
-int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config)
+uint32_t nrf_802154_ant_div_config_get(nrf_802154_ant_div_config_t * p_ant_div_config)
 {
     assert(p_ant_div_config != NULL);
     *p_ant_div_config = m_ant_div_config;
     return NRF_SUCCESS;
 }
 
-int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna)
+uint32_t nrf_802154_ant_div_antenna_set(nrf_802154_ant_div_antenna_t antenna)
 {
-    nrf_gpio_pin_write(m_ant_div_config.ant_sel_pin, antenna);
+    uint32_t status = NRF_SUCCESS;
+
+    if (NRF_ANT_DIV_ANTENNA_1 == antenna || NRF_ANT_DIV_ANTENNA_2 == antenna )
+    {
+        nrf_gpio_pin_write(m_ant_div_config.ant_sel_pin, antenna);
+    }
+    else
+    {
+        status = NRF_ERROR_INVALID_PARAM;
+    }
+
+    return status;
+}
+
+uint32_t nrf_802154_ant_div_antenna_get(nrf_802154_ant_div_antenna_t * p_antenna)
+{
+    *p_antenna = nrf_gpio_pin_out_read(m_ant_div_config.ant_sel_pin);
     return NRF_SUCCESS;
 }
 
-int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna)
-{
-    *antenna = (NRF_GPIO->OUT >> m_ant_div_config.ant_sel_pin) & 0x01;
-    return NRF_SUCCESS;
-}
-#else //ENABLE_ANT_DIV
-
-int32_t nrf_802154_ant_div_init()
-{
-    return NRF_ERROR_NOT_SUPPORTED;
-}
-
-int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config)
-{
-    (void)p_ant_div_config;
-    return NRF_ERROR_NOT_SUPPORTED;
-}
-
-int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config)
-{
-    (void)p_ant_div_config;
-    return NRF_ERROR_NOT_SUPPORTED;
-}
-
-int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna)
-{
-    (void)antenna;
-    return NRF_ERROR_NOT_SUPPORTED;
-}
-
-int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna)
-{
-    (void)antenna;
-    return NRF_ERROR_NOT_SUPPORTED;
-}
-
-#endif //ENABLE_ANT_DIV
+#endif // ENABLE_ANT_DIV

--- a/src/nrf_802154_ant_div.c
+++ b/src/nrf_802154_ant_div.c
@@ -69,7 +69,7 @@ uint32_t nrf_802154_ant_div_antenna_set(nrf_802154_ant_div_antenna_t antenna)
 {
     uint32_t status = NRF_SUCCESS;
 
-    if (NRF_ANT_DIV_ANTENNA_1 == antenna || NRF_ANT_DIV_ANTENNA_2 == antenna )
+    if ((NRF_ANT_DIV_ANTENNA_1 == antenna) || (NRF_ANT_DIV_ANTENNA_2 == antenna))
     {
         nrf_gpio_pin_write(m_ant_div_config.ant_sel_pin, antenna);
     }

--- a/src/nrf_802154_ant_div.h
+++ b/src/nrf_802154_ant_div.h
@@ -51,6 +51,9 @@ typedef struct
     uint8_t ant_sel_pin; /* Pin used for antenna selection */
 } nrf_802154_ant_div_config_t;
 
+/**
+ * @brief Available antennas
+ */
 typedef enum
 {
     NRF_ANT_DIV_ANTENNA_1 = 0,

--- a/src/nrf_802154_ant_div.h
+++ b/src/nrf_802154_ant_div.h
@@ -1,0 +1,101 @@
+/* Copyright (c) 2017, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @brief 802.15.4 antenna diversity module.
+ */
+#include "stdint.h"
+
+#define NRF_ANT_DIV_ANT_SEL_DEFAULT_PIN 23
+
+/**
+ * @brief Configuration structure for antenna diversity
+ */
+typedef struct{
+    uint8_t ant_sel_pin;        /* Pin used for antenna selection */
+} nrf_802154_ant_div_config_t;
+
+typedef enum{
+    NRF_ANT_DIV_ANTENNA_1 = 0,
+    NRF_ANT_DIV_ANTENNA_2 = 1
+} nrf_802154_ant_div_antenna_t;
+
+/**
+ * @brief Initializes antenna diversity module.
+ *
+ * If pinout other than default is to be used, @ref nrf_802154_ant_div_set_config 
+ * should be called before this function.
+ *  
+ * @retval ::NRF_SUCCESS             Antenna switched successfully
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
+ */
+int32_t nrf_802154_ant_div_init();
+
+/**
+ * @brief Sets the antenna diversity configuration.
+ * 
+ * Should not be called after @ref nrf_802154_ant_div_init.
+ * 
+ * @param[in] ant_div_config   Pointer to the antenna diversity configuration structure.
+ *
+ * @retval ::NRF_SUCCESS             Configuration set successfully
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported 
+ */
+int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config);
+
+/**
+ * @brief Retrieves te antenna diversity configuration.
+ *
+ * @param[out] ant_div_config  Pointer to configuration structure to be populated.
+ * 
+ * @retval ::NRF_SUCCESS             Configuration retrieved successfully
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
+ */
+int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config);
+
+/**
+ * @brief Select an antenna to use.
+ *
+ * @param[in] antenna          Antenna to be used
+ * 
+ * @retval ::NRF_SUCCESS             Antenna switched successfully
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
+ */
+int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna);
+
+/**
+ * @brief Get currently used antenna.
+ *
+ * @param[out] antenna         Currently used antenna. Not modified if antenna diversity is not supported.
+ * 
+ * @retval ::NRF_SUCCESS             Antenna switched successfully
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
+ */
+int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna);

--- a/src/nrf_802154_ant_div.h
+++ b/src/nrf_802154_ant_div.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2019, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,71 +31,119 @@
 /**
  * @brief 802.15.4 antenna diversity module.
  */
-#include "stdint.h"
 
-#define NRF_ANT_DIV_ANT_SEL_DEFAULT_PIN 23
+#ifndef NRF_802154_ANT_DIV_H
+#define NRF_802154_ANT_DIV_H
+
+#include <stdint.h>
+
+#include "nrf_error.h"
+
+#ifndef NRF_802154_ANT_DIV_ANT_SEL_DEFAULT_PIN
+#define NRF_802154_ANT_DIV_ANT_SEL_DEFAULT_PIN 23
+#endif
 
 /**
  * @brief Configuration structure for antenna diversity
  */
-typedef struct{
-    uint8_t ant_sel_pin;        /* Pin used for antenna selection */
+typedef struct
+{
+    uint8_t ant_sel_pin; /* Pin used for antenna selection */
 } nrf_802154_ant_div_config_t;
 
-typedef enum{
+typedef enum
+{
     NRF_ANT_DIV_ANTENNA_1 = 0,
     NRF_ANT_DIV_ANTENNA_2 = 1
 } nrf_802154_ant_div_antenna_t;
 
+#if ENABLE_ANT_DIV
 /**
  * @brief Initializes antenna diversity module.
  *
- * If pinout other than default is to be used, @ref nrf_802154_ant_div_set_config 
+ * If pinout other than default is to be used, @ref nrf_802154_ant_div_set_config
  * should be called before this function.
- *  
- * @retval ::NRF_SUCCESS             Antenna switched successfully
+ *
+ * @retval ::NRF_SUCCESS             Antenna diversity module initialized successfuly
  * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
  */
-int32_t nrf_802154_ant_div_init();
+uint32_t nrf_802154_ant_div_init(void);
 
 /**
  * @brief Sets the antenna diversity configuration.
- * 
+ *
  * Should not be called after @ref nrf_802154_ant_div_init.
- * 
- * @param[in] ant_div_config   Pointer to the antenna diversity configuration structure.
+ *
+ * @param[in] ant_div_config  Pointer to the antenna diversity configuration structure.
  *
  * @retval ::NRF_SUCCESS             Configuration set successfully
- * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported 
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
  */
-int32_t nrf_802154_ant_div_set_config(nrf_802154_ant_div_config_t *p_ant_div_config);
+uint32_t nrf_802154_ant_div_config_set(const nrf_802154_ant_div_config_t * p_ant_div_config);
 
 /**
  * @brief Retrieves te antenna diversity configuration.
  *
  * @param[out] ant_div_config  Pointer to configuration structure to be populated.
- * 
+ *
  * @retval ::NRF_SUCCESS             Configuration retrieved successfully
  * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
  */
-int32_t nrf_802154_ant_div_get_config(nrf_802154_ant_div_config_t *p_ant_div_config);
+uint32_t nrf_802154_ant_div_config_get(nrf_802154_ant_div_config_t * p_ant_div_config);
 
 /**
  * @brief Select an antenna to use.
  *
- * @param[in] antenna          Antenna to be used
- * 
+ * @param[in] antenna  Antenna to be used
+ *
  * @retval ::NRF_SUCCESS             Antenna switched successfully
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid antenna passed to the function
  * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
  */
-int32_t nrf_802154_ant_div_set_antenna(nrf_802154_ant_div_antenna_t antenna);
+uint32_t nrf_802154_ant_div_antenna_set(nrf_802154_ant_div_antenna_t antenna);
 
 /**
  * @brief Get currently used antenna.
  *
- * @param[out] antenna         Currently used antenna. Not modified if antenna diversity is not supported.
- * 
- * @retval ::NRF_SUCCESS             Antenna switched successfully
+ * @param[out] antenna  Currently used antenna. Not modified if antenna diversity is not supported.
+ *
+ * @retval ::NRF_SUCCESS             Current antenna retrieved successfuly
  * @retval ::NRF_ERROR_NOT_SUPPORTED Antenna diversity module is not supported
  */
-int32_t nrf_802154_ant_div_get_antenna(nrf_802154_ant_div_antenna_t *antenna);
+uint32_t nrf_802154_ant_div_antenna_get(nrf_802154_ant_div_antenna_t * p_antenna);
+
+#else // ENABLE_ANT_DIV
+
+static inline uint32_t nrf_802154_ant_div_init(void)
+{
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+static inline uint32_t nrf_802154_ant_div_config_set(
+    const nrf_802154_ant_div_config_t * p_ant_div_config)
+{
+    (void)p_ant_div_config;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+static inline uint32_t nrf_802154_ant_div_config_get(nrf_802154_ant_div_config_t * p_ant_div_config)
+{
+    (void)p_ant_div_config;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+static inline uint32_t nrf_802154_ant_div_antenna_set(nrf_802154_ant_div_antenna_t antenna)
+{
+    (void)antenna;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+static inline uint32_t nrf_802154_ant_div_antenna_get(nrf_802154_ant_div_antenna_t * p_antenna)
+{
+    (void)p_antenna;
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+#endif // ENABLE_ANT_DIV
+
+#endif // NRF_802154_ANT_DIV_H


### PR DESCRIPTION
  * Antenna diversity module created and added to packsc.
  * ant_div option added to packsc
  * Antenna diversity implements:
    - Pinout configuration
    - Initialization
    - Antenna selection
    - Retrieving current antenna
  * Stubs provided for non-ant_div builds

On-desk manual tests passed.