### PR TITLE
Pr/log rx stats

### DIFF
--- a/src/nrf_802154_config.h
+++ b/src/nrf_802154_config.h
@@ -480,6 +480,19 @@ extern "C" {
 #endif
 
 /**
+ * @def NRF_802154_STATS_COUNT_RECEIVED_PREAMBLES
+ *
+ * Configures if number of received preambles will be counted in receive mode.
+ * When this option is enabled additional interrupts on preamble reveived will occur
+ * increasing power consumption. The events counter is stored in
+ * @ref nrf_802154_stat_counters_t::received_preambles field and can be retrieved by
+ * a call to @ref nrf_802154_stats_get or @ref nrf_802154_stat_counters_get.
+ */
+#ifndef NRF_802154_STATS_COUNT_RECEIVED_PREAMBLES
+#define NRF_802154_STATS_COUNT_RECEIVED_PREAMBLES 1
+#endif
+
+/**
  *@}
  **/
 

--- a/src/nrf_802154_config.h
+++ b/src/nrf_802154_config.h
@@ -461,6 +461,25 @@ extern "C" {
 #endif
 
 /**
+ * @}
+ * @defgroup nrf_802154_stats Statistics configuration
+ * @{
+ */
+
+/**
+ * @def NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS
+ *
+ * Configures if energy detected events will be counted in receive mode.
+ * When this option is enabled additional interrupts on energy detected events will occur
+ * increasing power consumption. The events counter is stored in
+ * @ref nrf_802154_stat_counters_t::received_energy_events field and can be retrieved by
+ * a call to @ref nrf_802154_stats_get or @ref nrf_802154_stat_counters_get.
+ */
+#ifndef NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS
+#define NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS 1
+#endif
+
+/**
  *@}
  **/
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -741,6 +741,9 @@ static nrf_802154_trx_receive_notifications_t make_trx_frame_receive_notificatio
 #if (NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS)
     result |= TRX_RECEIVE_NOTIFICATION_PRESTARTED;
 #endif
+#if (NRF_802154_STATS_COUNT_RECEIVED_PREAMBLES)
+    result |= TRX_RECEIVE_NOTIFICATION_STARTED;
+#endif
 
     if (nrf_802154_wifi_coex_is_enabled())
     {
@@ -1258,10 +1261,24 @@ void nrf_802154_trx_receive_frame_started(void)
     assert(m_state == RADIO_STATE_RX);
     assert((m_trx_receive_frame_notifications_mask & TRX_RECEIVE_NOTIFICATION_STARTED) != 0U);
 
-    nrf_802154_timer_sched_remove(&m_rx_prestarted_timer, NULL);
+#if (NRF_802154_STATS_COUNT_RECEIVED_PREAMBLES)
+    nrf_802154_stat_counter_increment(received_preambles);
+#endif
 
-    /* Request boosted preconditions */
-    nrf_802154_rsch_crit_sect_prio_request(RSCH_PRIO_RX);
+    switch (nrf_802154_pib_coex_rx_request_mode_get())
+    {
+        case NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION:
+            nrf_802154_timer_sched_remove(&m_rx_prestarted_timer, NULL);
+        /* no break */
+
+        case NRF_802154_COEX_RX_REQUEST_MODE_PREAMBLE:
+            /* Request boosted preconditions */
+            nrf_802154_rsch_crit_sect_prio_request(RSCH_PRIO_RX);
+            break;
+
+        default:
+            break;
+    }
 
     nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_LOW);
 }

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -738,6 +738,10 @@ static nrf_802154_trx_receive_notifications_t make_trx_frame_receive_notificatio
 {
     nrf_802154_trx_receive_notifications_t result = TRX_RECEIVE_NOTIFICATION_NONE;
 
+#if (NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS)
+    result |= TRX_RECEIVE_NOTIFICATION_PRESTARTED;
+#endif
+
     if (nrf_802154_wifi_coex_is_enabled())
     {
         switch (nrf_802154_pib_coex_rx_request_mode_get())
@@ -1217,24 +1221,32 @@ void nrf_802154_trx_receive_frame_prestarted(void)
     assert(m_state == RADIO_STATE_RX);
     assert((m_trx_receive_frame_notifications_mask & TRX_RECEIVE_NOTIFICATION_PRESTARTED) != 0U);
 
-    /* This handler serves one main purpose: boosting preconditions for receive.
-     * This handler might not be followed by nrf_802154_trx_receive_frame_started.
-     * That's why we need to revert boosted precondition if nrf_802154_trx_receive_frame_started
-     * doesn't come. We use timer for this purpose.
-     */
+#if (NRF_802154_STATS_COUNT_ENERGY_DETECTED_EVENTS)
+    nrf_802154_stat_counter_increment(received_energy_events);
+#endif
 
-    uint32_t now = nrf_802154_timer_sched_time_get();
+    if (nrf_802154_pib_coex_rx_request_mode_get() ==
+        NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION)
+    {
+        /* Code below serves one main purpose: boosting preconditions for receive.
+         * This handler might not be followed by nrf_802154_trx_receive_frame_started.
+         * That's why we need to revert boosted precondition if nrf_802154_trx_receive_frame_started
+         * doesn't come. We use timer for this purpose.
+         */
 
-    nrf_802154_timer_sched_remove(&m_rx_prestarted_timer, NULL);
+        uint32_t now = nrf_802154_timer_sched_time_get();
 
-    /* Request boosted preconditions */
-    nrf_802154_rsch_crit_sect_prio_request(RSCH_PRIO_RX);
+        nrf_802154_timer_sched_remove(&m_rx_prestarted_timer, NULL);
 
-    m_rx_prestarted_timer.t0       = now;
-    m_rx_prestarted_timer.dt       = PRESTARTED_TIMER_TIMEOUT_US;
-    m_rx_prestarted_timer.callback = on_rx_prestarted_timeout;
+        /* Request boosted preconditions */
+        nrf_802154_rsch_crit_sect_prio_request(RSCH_PRIO_RX);
 
-    nrf_802154_timer_sched_add(&m_rx_prestarted_timer, true);
+        m_rx_prestarted_timer.t0       = now;
+        m_rx_prestarted_timer.dt       = PRESTARTED_TIMER_TIMEOUT_US;
+        m_rx_prestarted_timer.callback = on_rx_prestarted_timeout;
+
+        nrf_802154_timer_sched_add(&m_rx_prestarted_timer, true);
+    }
 
     nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_LOW);
 }

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1440,6 +1440,8 @@ void nrf_802154_trx_receive_frame_received(void)
 
     if (m_flags.frame_filtered || nrf_802154_pib_promiscuous_get())
     {
+        nrf_802154_stat_counter_increment(received_frames);
+
         bool send_ack = false;
 
         if (m_flags.frame_filtered &&

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -216,6 +216,8 @@ typedef struct
     uint32_t cca_failed_attempts;
     /**@brief Number of frames received with correct CRC and with filtering passing. */
     uint32_t received_frames;
+    /**@brief Number of times energy was detected in receive mode.*/
+    uint32_t received_energy_events;
 } nrf_802154_stat_counters_t;
 
 /**

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -218,6 +218,8 @@ typedef struct
     uint32_t received_frames;
     /**@brief Number of times energy was detected in receive mode.*/
     uint32_t received_energy_events;
+    /**@brief Number of times a preamble was received in receive mode. */
+    uint32_t received_preambles;
 } nrf_802154_stat_counters_t;
 
 /**

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -214,6 +214,8 @@ typedef struct
 {
     /**@brief Number of failed CCA attempts. */
     uint32_t cca_failed_attempts;
+    /**@brief Number of frames received with correct CRC and with filtering passing. */
+    uint32_t received_frames;
 } nrf_802154_stat_counters_t;
 
 /**


### PR DESCRIPTION
Implemented stat counters for:
- number of sync events (number of times energy detected during receive)
- number of received preambles
- number of received frames with CRCOK and filtering passing

This implementation requires additional interrupts to be enabled during receive. Because this can increase power consumption, this counters may be disabled at compile time. Agreed with @hubertmis that for counters disabled at compile time corresponding fields in `nrf_802154_stat_counters_t` remain (but won't be incremented because of compile-time configuration). Justification is to have coherent public api struct `nrf_802154_stat_counters_t` if the driver is compiled into lib and then linked with application. The api used by app will be then independent of compile-time configuration used when radio driver lib was compiled.