### PR TITLE
Count IFS from the previous frame timestamp

### DIFF
--- a/src/mac_features/nrf_802154_ifs.c
+++ b/src/mac_features/nrf_802154_ifs.c
@@ -170,7 +170,7 @@ bool nrf_802154_ifs_pretransmission(const uint8_t * p_frame, bool cca)
 
     m_context.p_data  = (uint8_t *)p_frame;
     m_context.cca     = cca;
-    m_timer.t0        = current_timestamp;
+    m_timer.t0        = m_last_frame_timestamp;
     m_timer.dt        = dt;
     m_timer.callback  = callback_fired;
     m_timer.p_context = &m_context;


### PR DESCRIPTION
Current implementation starts measuring the IFS period when transmission is requested. It's imprecise and the timestamp of the previous frame is kept anyway, so it can be used to measure the IFS period precisely.