### PR TITLE
Fix problem when CPU is halted during frame RX and FEM is disabled

### DIFF
--- a/test/unit tests/fsm_frame_filtering/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering/unity_test.c
@@ -359,6 +359,9 @@ static void mock_ack_requested_rx(void)
     uint32_t  event_addr;
     uint32_t  time_to_pa = rand();
 
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
+
     nrf_802154_ack_generator_create_ExpectAndReturn(m_test_rx_buffer.data, p_ack);
     nrf_radio_packetptr_set_Expect(p_ack);
     nrf_radio_shorts_set_Expect(NRF_RADIO_SHORT_TXREADY_START_MASK |
@@ -380,8 +383,8 @@ static void mock_ack_requested_rx(void)
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
 
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, 1);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, 2);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, time_to_pa - 1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, time_to_pa + 1);
 
     nrf_radio_int_disable_Expect(NRF_RADIO_INT_BCMATCH_MASK  |
                                  NRF_RADIO_INT_CRCERROR_MASK |

--- a/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
@@ -312,6 +312,9 @@ static void mock_ack_requested(void)
     uint32_t  event_addr;
     uint32_t  time_to_pa = rand();
 
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
+
     nrf_802154_ack_generator_create_ExpectAndReturn(m_test_radio_buffer.data, p_ack);
     nrf_radio_packetptr_set_Expect(p_ack);
     nrf_radio_shorts_set_Expect(NRF_RADIO_SHORT_TXREADY_START_MASK |
@@ -335,8 +338,8 @@ static void mock_ack_requested(void)
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
 
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, 1);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, 2);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, time_to_pa - 1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, time_to_pa + 1);
 
     nrf_radio_int_disable_Expect(NRF_RADIO_INT_CRCOK_MASK | NRF_RADIO_INT_CRCERROR_MASK);
     nrf_radio_event_clear_Expect(NRF_RADIO_EVENT_PHYEND);

--- a/test/unit tests/fsm_rx/unity_test.c
+++ b/test/unit tests/fsm_rx/unity_test.c
@@ -493,12 +493,11 @@ void test_crcok_handler_ShallFilterFrame(void)
 
 // ACK requested
 
-static void crcok_ack_periph_set_verify(void)
+static void crcok_ack_periph_set_verify(uint32_t time_to_pa)
 {
     uint8_t * p_ack = (uint8_t *)rand();
     uint32_t  event_addr;
     uint32_t  task_addr;
-    uint32_t  time_to_pa;
 
     nrf_802154_frame_parser_ar_bit_is_set_ExpectAndReturn(m_buffer.data, true);
 
@@ -529,9 +528,12 @@ void test_crcok_handler_ShallPreparePeriphsToTransmitAckIfRequested(void)
     uint8_t * p_ack = (uint8_t *)rand();
     uint32_t  event_addr;
     uint32_t  task_addr;
-    uint32_t  timer_cc1;
+    uint32_t  timer_cc0;
     uint32_t  timer_cc3;
     uint32_t  time_to_pa = rand();
+
+    time_to_pa = (time_to_pa > 2) ? time_to_pa : 2; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
 
     insert_frame_with_ack_request_to_buffer();
 
@@ -559,11 +561,11 @@ void test_crcok_handler_ShallPreparePeriphsToTransmitAckIfRequested(void)
 
     nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRF_SUCCESS);
 
-    timer_cc1 = rand();
-    timer_cc3 = timer_cc1 - 1;
+    timer_cc0 = time_to_pa + 1;
+    timer_cc3 = time_to_pa - 2;
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, timer_cc3);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, timer_cc1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, timer_cc0);
 
     nrf_radio_int_disable_Expect(NRF_RADIO_INT_CRCERROR_MASK |
                                  NRF_RADIO_INT_BCMATCH_MASK  |
@@ -580,18 +582,22 @@ void test_crcok_handler_ShallPreparePeriphsToTransmitAckIfRequested(void)
 
 void test_crcok_handler_ShallWaitForPhyendEventIfTimerIsTicking(void)
 {
-    uint32_t timer_cc1;
+    uint32_t timer_cc0;
     uint32_t timer_cc3;
+    uint32_t time_to_pa = rand();
+
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
 
     insert_frame_with_ack_request_to_buffer();
 
-    crcok_ack_periph_set_verify();
+    crcok_ack_periph_set_verify(time_to_pa);
 
-    timer_cc1 = rand();
-    timer_cc3 = timer_cc1 - 1;
+    timer_cc0 = time_to_pa + 1;
+    timer_cc3 = time_to_pa - 1;
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, timer_cc3);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, timer_cc1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, timer_cc0);
 
     nrf_radio_int_disable_Expect(NRF_RADIO_INT_CRCERROR_MASK |
                                  NRF_RADIO_INT_BCMATCH_MASK  |
@@ -606,18 +612,22 @@ void test_crcok_handler_ShallWaitForPhyendEventIfTimerIsTicking(void)
 
 void test_crcok_handler_ShallWaitForPhyendEventIfTransmitterIsRampingUp(void)
 {
-    uint32_t timer_cc1;
+    uint32_t timer_cc0;
     uint32_t timer_cc3;
+    uint32_t time_to_pa = rand();
+
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
 
     insert_frame_with_ack_request_to_buffer();
 
-    crcok_ack_periph_set_verify();
+    crcok_ack_periph_set_verify(time_to_pa);
 
-    timer_cc1 = rand();
-    timer_cc3 = timer_cc1;
+    timer_cc0 = time_to_pa + 1;
+    timer_cc3 = timer_cc0;
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, timer_cc3);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, timer_cc1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, timer_cc0);
 
     nrf_radio_state_get_ExpectAndReturn(NRF_RADIO_STATE_TXRU);
 
@@ -634,18 +644,22 @@ void test_crcok_handler_ShallWaitForPhyendEventIfTransmitterIsRampingUp(void)
 
 void test_crcok_handler_ShallWaitForPhyendEventIfTransmitterEndedRampingUp(void)
 {
-    uint32_t timer_cc1;
+    uint32_t timer_cc0;
     uint32_t timer_cc3;
+    uint32_t time_to_pa = rand();
+
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
 
     insert_frame_with_ack_request_to_buffer();
 
-    crcok_ack_periph_set_verify();
+    crcok_ack_periph_set_verify(time_to_pa);
 
-    timer_cc1 = rand();
-    timer_cc3 = timer_cc1;
+    timer_cc0 = time_to_pa + 1;
+    timer_cc3 = timer_cc0;
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, timer_cc3);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, timer_cc1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, timer_cc0);
     nrf_radio_state_get_ExpectAndReturn(NRF_RADIO_STATE_TX);
 
     nrf_radio_event_check_ExpectAndReturn(NRF_RADIO_EVENT_TXREADY, true);
@@ -663,19 +677,23 @@ void test_crcok_handler_ShallWaitForPhyendEventIfTransmitterEndedRampingUp(void)
 
 void test_crcok_handler_ShallNotifyReceivedFrameAndStartRxIfTransmitterDidNotRampUp(void)
 {
-    uint32_t timer_cc1;
+    uint32_t timer_cc0;
     uint32_t timer_cc3;
+    uint32_t time_to_pa = rand();
+
+    time_to_pa = (time_to_pa > 0) ? time_to_pa : 1; // Time to ramp up must be greater than 0
+    time_to_pa = (time_to_pa < UINT32_MAX) ? time_to_pa : UINT32_MAX - 1; // Time to ramp up must be lower than max
 
     insert_frame_with_ack_request_to_buffer();
     m_buffer.free = false;
 
-    crcok_ack_periph_set_verify();
+    crcok_ack_periph_set_verify(time_to_pa);
 
-    timer_cc1 = rand();
-    timer_cc3 = timer_cc1;
+    timer_cc0 = time_to_pa + 1;
+    timer_cc3 = timer_cc0;
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL3, timer_cc3);
-    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, timer_cc1);
+    nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, timer_cc0);
     nrf_radio_state_get_ExpectAndReturn(NRF_RADIO_STATE_TX);
     nrf_radio_event_check_ExpectAndReturn(NRF_RADIO_EVENT_TXREADY, false);
 


### PR DESCRIPTION
If CPU is halted when a frame is received, the timer responsible for
ACK transmission may overflow. Overflow of the timer was not detected
in software what lead to the driver hanging in the TX_ACK state.

Detection of timer overflow has been added to the code of the driver.