### PR TITLE
Clear shared PPI channel when the driver stops using it.

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1042,6 +1042,8 @@ static void rx_terminate(void)
     nrf_ppi_channel_disable(PPI_CRCOK_DIS_PPI);
     nrf_ppi_channel_disable(PPI_ADDRESS_COUNTER_COUNT);
     nrf_ppi_channel_disable(PPI_CRCERROR_COUNTER_CLEAR);
+    nrf_ppi_channel_endpoint_setup(PPI_CRCERROR_CLEAR, 0, 0);
+    nrf_ppi_fork_endpoint_setup(PPI_CRCERROR_CLEAR, 0);
 #endif // NRF_802154_DISABLE_BCC_MATCHING
 
     // Disable LNA
@@ -1106,6 +1108,8 @@ static void tx_ack_terminate(void)
 #if NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_disable(PPI_CRCERROR_CLEAR);
     nrf_ppi_channel_disable(PPI_CRCOK_DIS_PPI);
+    nrf_ppi_channel_endpoint_setup(PPI_CRCERROR_CLEAR, 0, 0);
+    nrf_ppi_fork_endpoint_setup(PPI_CRCERROR_CLEAR, 0);
 #endif // NRF_802154_DISABLE_BCC_MATCHING
 
     // Disable PA
@@ -2252,6 +2256,8 @@ static void irq_crcok_state_rx(void)
 
 #if !NRF_802154_DISABLE_BCC_MATCHING
                 nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
+                nrf_ppi_channel_endpoint_setup(PPI_TIMER_TX_ACK, 0, 0);
+                nrf_ppi_fork_endpoint_setup(PPI_TIMER_TX_ACK, 0);
 #endif // !NRF_802154_DISABLE_BCC_MATCHING
 
                 // RX uses the same peripherals as TX_ACK until RADIO ints are updated.
@@ -2382,7 +2388,9 @@ static void irq_phyend_state_tx_ack(void)
                                     NRF_TIMER_TASK_START));
 #else // NRF_802154_DISABLE_BCC_MATCHING
     nrf_ppi_channel_disable(PPI_TIMER_TX_ACK);
-#endif  // NRF_802154_DISABLE_BCC_MATCHING
+    nrf_ppi_channel_endpoint_setup(PPI_TIMER_TX_ACK, 0, 0);
+    nrf_ppi_fork_endpoint_setup(PPI_TIMER_TX_ACK, 0);
+#endif // NRF_802154_DISABLE_BCC_MATCHING
 
     // Enable PPI disabled by CRCOK
     nrf_ppi_channel_enable(PPI_EGU_RAMP_UP);

--- a/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
@@ -170,6 +170,8 @@ static void mock_rx_terminate(void)
     nrf_ppi_channel_disable_Expect(PPI_CRCOK_DIS_PPI);
     nrf_ppi_channel_disable_Expect(PPI_ADDRESS_COUNTER_COUNT);
     nrf_ppi_channel_disable_Expect(PPI_CRCERROR_COUNTER_CLEAR);
+    nrf_ppi_channel_endpoint_setup_Expect(PPI_CRCERROR_CLEAR, 0, 0);
+    nrf_ppi_fork_endpoint_setup_Expect(PPI_CRCERROR_CLEAR, 0);
 
     nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);

--- a/test/unit tests/fsm_rx/unity_test.c
+++ b/test/unit tests/fsm_rx/unity_test.c
@@ -698,6 +698,8 @@ void test_crcok_handler_ShallNotifyReceivedFrameAndStartRxIfTransmitterDidNotRam
     nrf_radio_event_check_ExpectAndReturn(NRF_RADIO_EVENT_TXREADY, false);
 
     nrf_ppi_channel_disable_Expect(PPI_TIMER_TX_ACK);
+    nrf_ppi_channel_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0, 0);
+    nrf_ppi_fork_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0);
 
     rx_terminate_periph_reset_verify(true);
 
@@ -892,6 +894,8 @@ static void verify_phyend_tx_ack_periph_reset(void)
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_disable_Expect(PPI_TIMER_TX_ACK);
+    nrf_ppi_channel_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0, 0);
+    nrf_ppi_fork_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0);
     nrf_ppi_channel_enable_Expect(PPI_EGU_RAMP_UP);
 
     nrf_egu_event_clear_Expect(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT);
@@ -934,6 +938,8 @@ void test_phyend_handler_ShallResetPeripheralsForRxStateAndNotfiThatFrameWasRece
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_disable_Expect(PPI_TIMER_TX_ACK);
+    nrf_ppi_channel_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0, 0);
+    nrf_ppi_fork_endpoint_setup_Expect(PPI_TIMER_TX_ACK, 0);
     nrf_ppi_channel_enable_Expect(PPI_EGU_RAMP_UP);
 
     nrf_egu_event_clear_Expect(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT);


### PR DESCRIPTION
There was a problem with FEM initialization if the driver left some data
in disabled PPI channel. Now PPI channel is cleared when the driver ends
using it.

This is a backport of #316 to master branch