### PR TITLE
/* Fallthrough */ comment used in switch case with intentional fall-through

### DIFF
--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -1461,7 +1461,7 @@ void nrf_802154_trx_receive_frame_started(void)
     {
         case NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION:
             nrf_802154_timer_sched_remove(&m_rx_prestarted_timer, NULL);
-        /* no break */
+        /* Fallthrough */
 
         case NRF_802154_COEX_RX_REQUEST_MODE_PREAMBLE:
             /* Request boosted preconditions */

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -1554,7 +1554,7 @@ bool nrf_802154_trx_go_idle(void)
 
         case TRX_STATE_RXFRAME_FINISHED:
             nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-        /* fallthrough */
+        /* Fallthrough */
 
         case TRX_STATE_FINISHED:
             go_idle_from_state_finished();


### PR DESCRIPTION
This comment is recognized by gcc 7.3.1, and disables warning when -Wimplicit-fallthrough=3 (implied by -Wextra) is used.