### PR TITLE
port use of nrf_error.h to nrfx_errors.h as provided by upstream nrfx repo

### DIFF
--- a/src/fem/nrf_fem_control_config.h
+++ b/src/fem/nrf_fem_control_config.h
@@ -38,7 +38,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "nrf_error.h"
+#include "nrfx_errors.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,8 +60,8 @@ extern "C" {
  *
  * @param[in] p_config Pointer to the interface parameters for the PA/LNA device.
  *
- * @retval   ::NRF_SUCCESS                 PA/LNA control successfully configured.
- * @retval   ::NRF_ERROR_NOT_SUPPORTED     PA/LNA is not available.
+ * @retval   ::NRFX_SUCCESS                PA/LNA control successfully configured.
+ * @retval   ::NRFX_ERROR_NOT_SUPPORTED    PA/LNA is not available.
  *
  */
 int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * const p_config);
@@ -75,8 +75,8 @@ int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * c
  *
  * @param[in] p_config Pointer to the interface parameters for the PA/LNA device to be populated.
  *
- * @retval   ::NRF_SUCCESS                 PA/LNA control successfully configured.
- * @retval   ::NRF_ERROR_NOT_SUPPORTED     PA/LNA is not available.
+ * @retval   ::NRFX_SUCCESS                PA/LNA control successfully configured.
+ * @retval   ::NRFX_ERROR_NOT_SUPPORTED    PA/LNA is not available.
  *
  */
 int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_config);
@@ -89,13 +89,13 @@ static inline int32_t nrf_fem_interface_configuration_set(
     nrf_fem_interface_config_t const * const p_config)
 {
     (void)p_config;
-    return NRF_ERROR_NOT_SUPPORTED;
+    return NRFX_ERROR_NOT_SUPPORTED;
 }
 
 static inline int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_config)
 {
     (void)p_config;
-    return NRF_ERROR_NOT_SUPPORTED;
+    return NRFX_ERROR_NOT_SUPPORTED;
 }
 
 #endif // ENABLE_FEM

--- a/src/fem/nrf_fem_protocol_api.h
+++ b/src/fem/nrf_fem_protocol_api.h
@@ -49,7 +49,7 @@
 #include "nrf_fem_control_config.h"
 #include "nrf_fem_protocol_legacy_api.h"
 
-#include "nrf_error.h"
+#include "nrfx_errors.h"
 #include "nrf_ppi.h"
 #include "nrf_timer.h"
 
@@ -124,9 +124,9 @@ typedef struct
  * @note If a timer event is provided, the caller of this function is responsible for starting the timer and its shorts.
  *       Moreover, the caller is responsible for stopping the timer no earlier than the provided compare channel expires.
  *
- * @retval   ::NRF_SUCCESS               PA activate setup is successful.
- * @retval   ::NRF_ERROR_FORBIDDEN       PA is currently disabled.
- * @retval   ::NRF_ERROR_INVALID_STATE   PA activate setup could not be performed due to invalid or missing configuration parameters
+ * @retval   ::NRFX_SUCCESS              PA activate setup is successful.
+ * @retval   ::NRFX_ERROR_FORBIDDEN      PA is currently disabled.
+ * @retval   ::NRFX_ERROR_INVALID_STATE  PA activate setup could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
 int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -138,9 +138,9 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
  * @param[in] p_activate_event   Pointer to the activation event structure.
  * @param[in] p_deactivate_event Pointer to the deactivation event structure.
  *
- * @retval   ::NRF_SUCCESS               PA activate setup purge is successful.
- * @retval   ::NRF_ERROR_FORBIDDEN       PA is currently disabled.
- * @retval   ::NRF_ERROR_INVALID_STATE   PA activate setup purge could not be performed due to invalid or missing configuration parameters
+ * @retval   ::NRFX_SUCCESS              PA activate setup purge is successful.
+ * @retval   ::NRFX_ERROR_FORBIDDEN      PA is currently disabled.
+ * @retval   ::NRFX_ERROR_INVALID_STATE  PA activate setup purge could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
 int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
@@ -168,9 +168,9 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
  * @note If a timer event is provided, the caller of this function is responsible for starting the timer and its shorts.
  *       Moreover, the caller is responsible for stopping the timer no earlier than the provided compare channel expires.
  *
- * @retval   ::NRF_SUCCESS               LNA activate setup is successful.
- * @retval   ::NRF_ERROR_FORBIDDEN       LNA is currently disabled.
- * @retval   ::NRF_ERROR_INVALID_STATE   LNA activate setup could not be performed due to invalid or missing configuration parameters
+ * @retval   ::NRFX_SUCCESS              LNA activate setup is successful.
+ * @retval   ::NRFX_ERROR_FORBIDDEN      LNA is currently disabled.
+ * @retval   ::NRFX_ERROR_INVALID_STATE  LNA activate setup could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
 int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -182,9 +182,9 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
  * @param[in] p_activate_event   Pointer to the activation event structure.
  * @param[in] p_deactivate_event Pointer to the deactivation event structure.
  *
- * @retval   ::NRF_SUCCESS               LNA activate setup purge is successful.
- * @retval   ::NRF_ERROR_FORBIDDEN       LNA is currently disabled.
- * @retval   ::NRF_ERROR_INVALID_STATE   LNA activate setup purge could not be performed due to invalid or missing configuration parameters
+ * @retval   ::NRFX_SUCCESS              LNA activate setup purge is successful.
+ * @retval   ::NRFX_ERROR_FORBIDDEN      LNA is currently disabled.
+ * @retval   ::NRFX_ERROR_INVALID_STATE  LNA activate setup purge could not be performed due to invalid or missing configuration parameters
  *                                       in p_activate_event or p_deactivate_event, or both.
  */
 int32_t nrf_802154_fal_lna_configuration_clear(
@@ -234,7 +234,7 @@ static inline int32_t nrf_802154_fal_pa_configuration_set(
 {
     (void)p_activate_event;
     (void)p_deactivate_event;
-    return NRF_ERROR_FORBIDDEN;
+    return NRFX_ERROR_FORBIDDEN;
 }
 
 static inline int32_t nrf_802154_fal_pa_configuration_clear(
@@ -243,7 +243,7 @@ static inline int32_t nrf_802154_fal_pa_configuration_clear(
 {
     (void)p_activate_event;
     (void)p_deactivate_event;
-    return NRF_ERROR_FORBIDDEN;
+    return NRFX_ERROR_FORBIDDEN;
 }
 
 static inline int32_t nrf_802154_fal_lna_configuration_set(
@@ -252,7 +252,7 @@ static inline int32_t nrf_802154_fal_lna_configuration_set(
 {
     (void)p_activate_event;
     (void)p_deactivate_event;
-    return NRF_ERROR_FORBIDDEN;
+    return NRFX_ERROR_FORBIDDEN;
 }
 
 static inline int32_t nrf_802154_fal_lna_configuration_clear(
@@ -261,7 +261,7 @@ static inline int32_t nrf_802154_fal_lna_configuration_clear(
 {
     (void)p_activate_event;
     (void)p_deactivate_event;
-    return NRF_ERROR_FORBIDDEN;
+    return NRFX_ERROR_FORBIDDEN;
 }
 
 static inline void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)

--- a/src/fem/simple_gpio/nrf_fem_simple_gpio.c
+++ b/src/fem/simple_gpio/nrf_fem_simple_gpio.c
@@ -42,7 +42,7 @@
 #include "compiler_abstraction.h"
 #include "nrf_802154_config.h"
 #include "nrf.h"
-#include "nrf_error.h"
+#include "nrfx_errors.h"
 #include "nrf_gpio.h"
 #include "nrf_gpiote.h"
 #include "nrf_ppi.h"
@@ -146,7 +146,7 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
         }
         else
         {
-            return NRF_ERROR_INVALID_STATE;
+            return NRFX_ERROR_INVALID_STATE;
         }
     }
     else
@@ -208,7 +208,7 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
             break;
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 /** Deconfigure the event with the provided values. */
@@ -247,7 +247,7 @@ static int32_t event_configuration_clear(const nrf_802154_fal_event_t * const p_
             break;
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -257,7 +257,7 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
 
     if (!m_nrf_fem_interface_config.pa_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
@@ -266,7 +266,7 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
                                            &m_nrf_fem_interface_config.pa_pin_config,
                                            true,
                                            m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -278,13 +278,13 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
                                            &m_nrf_fem_interface_config.pa_pin_config,
                                            false,
                                            m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -294,7 +294,7 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
 
     if (!m_nrf_fem_interface_config.lna_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
@@ -303,7 +303,7 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
                                            &m_nrf_fem_interface_config.lna_pin_config,
                                            true,
                                            m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -315,13 +315,13 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
                                            &m_nrf_fem_interface_config.lna_pin_config,
                                            false,
                                            m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
@@ -331,13 +331,13 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
 
     if (!m_nrf_fem_interface_config.pa_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
     {
         ret_code = event_configuration_clear(p_activate_event, true);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -346,13 +346,13 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
     if (p_deactivate_event)
     {
         ret_code = event_configuration_clear(p_deactivate_event, false);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_lna_configuration_clear(
@@ -363,13 +363,13 @@ int32_t nrf_802154_fal_lna_configuration_clear(
 
     if (!m_nrf_fem_interface_config.lna_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
     {
         ret_code = event_configuration_clear(p_activate_event, true);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -378,13 +378,13 @@ int32_t nrf_802154_fal_lna_configuration_clear(
     if (p_deactivate_event)
     {
         ret_code = event_configuration_clear(p_deactivate_event, false);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)
@@ -428,14 +428,14 @@ int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * c
         gpiote_configure();
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_config)
 {
     *p_config = m_nrf_fem_interface_config;
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 void nrf_802154_fal_cleanup(void)

--- a/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
+++ b/src/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c
@@ -42,7 +42,7 @@
 #include "compiler_abstraction.h"
 #include "nrf_802154_config.h"
 #include "nrf.h"
-#include "nrf_error.h"
+#include "nrfx_errors.h"
 #include "nrf_gpio.h"
 #include "nrf_gpiote.h"
 #include "nrf_ppi.h"
@@ -183,7 +183,7 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
         }
         else
         {
-            return NRF_ERROR_INVALID_STATE;
+            return NRFX_ERROR_INVALID_STATE;
         }
     }
     else
@@ -281,7 +281,7 @@ static int32_t event_configuration_set(const nrf_802154_fal_event_t * const p_ev
             break;
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 /** Deconfigure the event with the provided values. */
@@ -318,7 +318,7 @@ static int32_t event_configuration_clear(const nrf_802154_fal_event_t * const p_
             break;
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -328,7 +328,7 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
 
     if (!m_nrf_fem_interface_config.pa_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
@@ -337,7 +337,7 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
                                            &m_nrf_fem_interface_config.pa_pin_config,
                                            true,
                                            m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -349,13 +349,13 @@ int32_t nrf_802154_fal_pa_configuration_set(const nrf_802154_fal_event_t * const
                                            &m_nrf_fem_interface_config.pa_pin_config,
                                            false,
                                            m_nrf_fem_interface_config.fem_config.pa_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * const p_activate_event,
@@ -365,7 +365,7 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
 
     if (!m_nrf_fem_interface_config.lna_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
@@ -374,7 +374,7 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
                                            &m_nrf_fem_interface_config.lna_pin_config,
                                            true,
                                            m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -386,13 +386,13 @@ int32_t nrf_802154_fal_lna_configuration_set(const nrf_802154_fal_event_t * cons
                                            &m_nrf_fem_interface_config.lna_pin_config,
                                            false,
                                            m_nrf_fem_interface_config.fem_config.lna_time_gap_us);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * const p_activate_event,
@@ -402,13 +402,13 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
 
     if (!m_nrf_fem_interface_config.pa_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
     {
         ret_code = event_configuration_clear(p_activate_event, true);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -417,13 +417,13 @@ int32_t nrf_802154_fal_pa_configuration_clear(const nrf_802154_fal_event_t * con
     if (p_deactivate_event)
     {
         ret_code = event_configuration_clear(p_deactivate_event, false);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_802154_fal_lna_configuration_clear(
@@ -434,13 +434,13 @@ int32_t nrf_802154_fal_lna_configuration_clear(
 
     if (!m_nrf_fem_interface_config.lna_pin_config.enable)
     {
-        return NRF_ERROR_FORBIDDEN;
+        return NRFX_ERROR_FORBIDDEN;
     }
 
     if (p_activate_event)
     {
         ret_code = event_configuration_clear(p_activate_event, true);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
@@ -449,13 +449,13 @@ int32_t nrf_802154_fal_lna_configuration_clear(
     if (p_deactivate_event)
     {
         ret_code = event_configuration_clear(p_deactivate_event, false);
-        if (ret_code != NRF_SUCCESS)
+        if (ret_code != NRFX_SUCCESS)
         {
             return ret_code;
         }
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 void nrf_802154_fal_deactivate_now(nrf_fal_functionality_t type)
@@ -499,14 +499,14 @@ int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * c
         gpiote_configure();
     }
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 int32_t nrf_fem_interface_configuration_get(nrf_fem_interface_config_t * p_config)
 {
     *p_config = m_nrf_fem_interface_config;
 
-    return NRF_SUCCESS;
+    return NRFX_SUCCESS;
 }
 
 void nrf_802154_fal_cleanup(void)

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -57,7 +57,7 @@
 #include "nrf_802154_types.h"
 #include "nrf_802154_utils.h"
 #include "nrf_egu.h"
-#include "nrf_error.h"
+#include "nrfx_errors.h"
 #include "nrf_ppi.h"
 #include "nrf_radio.h"
 #include "nrf_timer.h"
@@ -810,7 +810,7 @@ static void ppis_for_egu_and_ramp_up_set(nrf_radio_task_t ramp_up_task, bool sel
 /** Configure FEM to set LNA at appropriate time. */
 static void fem_for_lna_set(void)
 {
-    if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRF_SUCCESS)
+    if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRFX_SUCCESS)
     {
         uint32_t event_addr = (uint32_t)nrf_egu_event_address_get(NRF_802154_SWI_EGU_INSTANCE,
                                                                   EGU_EVENT);
@@ -839,7 +839,7 @@ static void fem_for_lna_reset(void)
 /** Configure FEM to set PA at appropriate time. */
 static void fem_for_pa_set(void)
 {
-    if (nrf_802154_fal_pa_configuration_set(&m_activate_tx_cc0, NULL) == NRF_SUCCESS)
+    if (nrf_802154_fal_pa_configuration_set(&m_activate_tx_cc0, NULL) == NRFX_SUCCESS)
     {
         uint32_t event_addr = (uint32_t)nrf_egu_event_address_get(NRF_802154_SWI_EGU_INSTANCE,
                                                                   EGU_EVENT);
@@ -872,12 +872,12 @@ static void fem_for_tx_set(bool cca)
         bool pa_set  = false;
         bool lna_set = false;
 
-        if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, &m_ccaidle) == NRF_SUCCESS)
+        if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, &m_ccaidle) == NRFX_SUCCESS)
         {
             lna_set = true;
         }
 
-        if (nrf_802154_fal_pa_configuration_set(&m_ccaidle, NULL) == NRF_SUCCESS)
+        if (nrf_802154_fal_pa_configuration_set(&m_ccaidle, NULL) == NRFX_SUCCESS)
         {
             pa_set = true;
         }
@@ -887,7 +887,7 @@ static void fem_for_tx_set(bool cca)
     }
     else
     {
-        success = (nrf_802154_fal_pa_configuration_set(&m_activate_tx_cc0, NULL) == NRF_SUCCESS);
+        success = (nrf_802154_fal_pa_configuration_set(&m_activate_tx_cc0, NULL) == NRFX_SUCCESS);
     }
 
     if (success)
@@ -1554,7 +1554,7 @@ static void rx_init(bool disabled_was_triggered)
 
     uint32_t delta_time;
 
-    if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRF_SUCCESS)
+    if (nrf_802154_fal_lna_configuration_set(&m_activate_rx_cc0, NULL) == NRFX_SUCCESS)
     {
         delta_time = nrf_timer_cc_read(NRF_802154_TIMER_INSTANCE,
                                        NRF_TIMER_CC_CHANNEL0);

--- a/src/platform/random/nrf_802154_random_newlib.c
+++ b/src/platform/random/nrf_802154_random_newlib.c
@@ -60,7 +60,7 @@ void nrf_802154_random_init(void)
     {
         result = sd_rand_application_vector_get((uint8_t *)&m_seed, sizeof(m_seed));
     }
-    while (result != NRF_SUCCESS);
+    while (result != NRFX_SUCCESS);
 #else // RAAL_SOFTDEVICE
     NRF_RNG->TASKS_START = 1;
 

--- a/src/platform/random/nrf_802154_random_stdlib.c
+++ b/src/platform/random/nrf_802154_random_stdlib.c
@@ -58,7 +58,7 @@ void nrf_802154_random_init(void)
     {
         result = sd_rand_application_vector_get((uint8_t *)&seed, sizeof(seed));
     }
-    while (result != NRF_SUCCESS);
+    while (result != NRFX_SUCCESS);
 #else // RAAL_SOFTDEVICE
     NRF_RNG->TASKS_START = 1;
 

--- a/src/rsch/raal/softdevice/nrf_raal_softdevice.c
+++ b/src/rsch/raal/softdevice/nrf_raal_softdevice.c
@@ -374,7 +374,7 @@ static void timeslot_request(void)
     // Request timeslot from SoftDevice.
     uint32_t err_code = sd_radio_request(&m_request);
 
-    if (err_code != NRF_SUCCESS)
+    if (err_code != NRFX_SUCCESS)
     {
         m_timeslot_state = TIMESLOT_STATE_IDLE;
     }
@@ -710,7 +710,7 @@ void nrf_raal_init(void)
 
     uint32_t err_code = sd_radio_session_open(signal_handler);
 
-    assert(err_code == NRF_SUCCESS);
+    assert(err_code == NRFX_SUCCESS);
     (void)err_code;
 
 #if (SD_VERSION == BLE_ADV_SCHED_CFG_SUPPORT_SD_VERSION)
@@ -725,7 +725,7 @@ void nrf_raal_init(void)
 
         err_code = sd_ble_opt_set(BLE_COMMON_OPT_ADV_SCHED_CFG, &opt);
 
-        assert(err_code == NRF_SUCCESS);
+        assert(err_code == NRFX_SUCCESS);
         (void)err_code;
     }
 #endif
@@ -745,7 +745,7 @@ void nrf_raal_uninit(void)
 
     uint32_t err_code = sd_radio_session_close();
 
-    assert(err_code == NRF_SUCCESS);
+    assert(err_code == NRFX_SUCCESS);
     (void)err_code;
 
     m_continuous     = false;

--- a/test/unit tests/fsm_cca/unity_test.c
+++ b/test/unit tests/fsm_cca/unity_test.c
@@ -101,7 +101,7 @@ static void verify_receive_begin_setup(uint32_t shorts)
                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     delta_time = rand();
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
@@ -225,7 +225,7 @@ static void verify_cca_begin_periph_setup(void)
     nrf_radio_int_enable_Expect(NRF_RADIO_INT_CCABUSY_MASK | NRF_RADIO_INT_CCAIDLE_MASK);
 
     // Set timer and PPIs for FEM
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     
     task_addr1 = rand();
     event_addr = rand();
@@ -318,7 +318,7 @@ static void verify_cca_terminate_periph_reset(bool in_timeslot)
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);

--- a/test/unit tests/fsm_cont_carrier/unity_test.c
+++ b/test/unit tests/fsm_cont_carrier/unity_test.c
@@ -108,7 +108,7 @@ static void verify_continuous_carrier_begin_periph_setup(void)
     nrf_802154_pib_tx_power_get_ExpectAndReturn(tx_power);
     nrf_radio_txpower_set_Expect(tx_power);
     
-    nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     event_addr = rand();
     task_addr = rand();
     nrf_egu_event_address_get_ExpectAndReturn(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT, (uint32_t *)event_addr);
@@ -195,7 +195,7 @@ void test_continuous_carrier_terminate_ShallDoNothingOutOfTimeslot(void)
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
     nrf_802154_fal_deactivate_now_Expect(NRF_802154_FAL_PA);
@@ -210,7 +210,7 @@ void test_continuous_carrier_terminate_ShallResetPeriphAndTriggerDisableTask(voi
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
     nrf_802154_fal_deactivate_now_Expect(NRF_802154_FAL_PA);

--- a/test/unit tests/fsm_ed/unity_test.c
+++ b/test/unit tests/fsm_ed/unity_test.c
@@ -102,7 +102,7 @@ static void verify_receive_begin_setup(uint32_t shorts)
                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     delta_time = rand();
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
@@ -228,7 +228,7 @@ static void verify_ed_begin_periph_setup(void)
     nrf_radio_event_clear_Expect(NRF_RADIO_EVENT_EDEND);
     nrf_radio_int_enable_Expect(NRF_RADIO_INT_EDEND_MASK);
 
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     event_addr = rand();
     nrf_egu_event_address_get_ExpectAndReturn(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT, (uint32_t *)event_addr);
     task_addr1 = rand();
@@ -320,7 +320,7 @@ static void verify_ed_terminate_periph_reset(bool is_in_timeslot)
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
@@ -415,7 +415,7 @@ void test_edend_handler_ShallWaitForNextTimeslotIfCannotStartNextIteration(void)
 
     nrf_802154_rsch_timeslot_us_left_get_ExpectAndReturn(0);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);

--- a/test/unit tests/fsm_frame_filtering/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering/unity_test.c
@@ -193,7 +193,7 @@ static void mock_rx_terminate(void)
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_remove_from_group_Expect(PPI_EGU_RAMP_UP, PPI_CHGRP0);
@@ -218,7 +218,7 @@ static void mock_rx_ack_terminate(void)
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
@@ -249,7 +249,7 @@ static void mock_tx_terminate(void)
                                     NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
                                     NRF_TIMER_SHORT_COMPARE1_STOP_MASK);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);    
 
@@ -298,7 +298,7 @@ static void mock_receive_begin(bool free_buffer, uint32_t shorts)
     // FEM setup
     nrf_timer_shorts_enable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     delta_time = rand();
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
 
@@ -379,7 +379,7 @@ static void mock_ack_requested_rx(void)
     nrf_ppi_channel_enable_Expect(PPI_TIMER_TX_ACK);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, time_to_pa);
-    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRFX_SUCCESS);
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
 
@@ -453,11 +453,11 @@ static void mock_ack_requested_tx(void)
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE,
                              NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
                              NRF_TIMER_SHORT_COMPARE1_STOP_MASK);
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     event_addr = rand();
     task_addr_1 = rand();
     nrf_egu_event_address_get_ExpectAndReturn(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT, (uint32_t *)event_addr);

--- a/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
+++ b/test/unit tests/fsm_frame_filtering_BCMATCH_disabled/unity_test.c
@@ -173,7 +173,7 @@ static void mock_rx_terminate(void)
     nrf_ppi_channel_endpoint_setup_Expect(PPI_CRCERROR_CLEAR, 0, 0);
     nrf_ppi_fork_endpoint_setup_Expect(PPI_CRCERROR_CLEAR, 0);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_remove_from_group_Expect(PPI_EGU_RAMP_UP, PPI_CHGRP0);
@@ -219,7 +219,7 @@ static void mock_receive_begin(uint32_t shorts)
     // FEM setup
     nrf_timer_shorts_enable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
     delta_time = rand();
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
 
@@ -336,7 +336,7 @@ static void mock_ack_requested(void)
     nrf_ppi_channel_endpoint_setup_Expect(PPI_TIMER_TX_ACK, event_addr, task_addr);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, time_to_pa);
-    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRFX_SUCCESS);
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_CAPTURE3);
 
@@ -732,9 +732,9 @@ void test_OnPhyEndStateTxAck_ShallResetCounterTimer(void)
 
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_radio_shorts_set_Expect(NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK |
                                 NRF_RADIO_SHORT_END_DISABLE_MASK);

--- a/test/unit tests/fsm_rx/unity_test.c
+++ b/test/unit tests/fsm_rx/unity_test.c
@@ -185,7 +185,7 @@ static void verify_receive_begin_setup(uint32_t shorts)
                             NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     delta_time = rand();
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
@@ -442,7 +442,7 @@ static inline void rx_terminate_periph_reset_verify(bool timeslot_granted)
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_remove_from_group_Expect(PPI_EGU_RAMP_UP, PPI_CHGRP0);
@@ -520,7 +520,7 @@ static void crcok_ack_periph_set_verify(uint32_t time_to_pa)
     nrf_ppi_channel_enable_Expect(PPI_TIMER_TX_ACK);
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, time_to_pa);
-    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRFX_SUCCESS);
 }
 
 void test_crcok_handler_ShallPreparePeriphsToTransmitAckIfRequested(void)
@@ -559,7 +559,7 @@ void test_crcok_handler_ShallPreparePeriphsToTransmitAckIfRequested(void)
 
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, time_to_pa);
 
-    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_IgnoreAndReturn(NRFX_SUCCESS);
 
     timer_cc0 = time_to_pa + 1;
     timer_cc3 = time_to_pa - 2;
@@ -873,9 +873,9 @@ static void verify_phyend_tx_ack_periph_reset(void)
 
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_radio_shorts_set_Expect(NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK |
                                 NRF_RADIO_SHORT_END_DISABLE_MASK       |
@@ -917,9 +917,9 @@ void test_phyend_handler_ShallResetPeripheralsForRxStateAndNotfiThatFrameWasRece
     // Set hardware
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_radio_shorts_set_Expect(NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK |
                                 NRF_RADIO_SHORT_END_DISABLE_MASK       |
@@ -1076,7 +1076,7 @@ void test_tx_ack_terminate_ShallNotModifyRadioRegistersOutOfTimeslot(void)
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_remove_from_group_Expect(PPI_EGU_RAMP_UP, PPI_CHGRP0);
@@ -1098,7 +1098,7 @@ void test_tx_ack_terminate_ShallResetShortsAndPpisAndTriggerTasksToStopHardware(
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     nrf_ppi_channel_remove_from_group_Expect(PPI_EGU_RAMP_UP, PPI_CHGRP0);

--- a/test/unit tests/fsm_tx/unity_test.c
+++ b/test/unit tests/fsm_tx/unity_test.c
@@ -196,7 +196,7 @@ static void verify_receive_begin_setup(uint32_t shorts)
 
     nrf_timer_shorts_enable_Expect(NRF_802154_TIMER_INSTANCE,
                                    NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_cc_read_ExpectAndReturn(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL0, delta_time);
     nrf_timer_cc_write_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_CC_CHANNEL1, delta_time + ACK_IFS - TXRU_TIME - EVENT_LAT);
 
@@ -300,8 +300,8 @@ static void verify_complete_ack_is_not_matched(void)
 
 static void verify_clearing_fem_config(void)
 {
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(NULL, &m_deactivate_on_disable, NRF_SUCCESS);
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(NULL, &m_deactivate_on_disable, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(NULL, &m_deactivate_on_disable, NRFX_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(NULL, &m_deactivate_on_disable, NRFX_SUCCESS);
 }
 
 void setUp(void)
@@ -400,12 +400,12 @@ static void verify_transmit_begin_periph_setup(bool cca)
     // Set timer and PPIs for FEM
     if (cca)
     {
-        nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, &m_ccaidle, NRF_SUCCESS);
-        nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_ccaidle, NULL, NRF_SUCCESS);
+        nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, &m_ccaidle, NRFX_SUCCESS);
+        nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_ccaidle, NULL, NRFX_SUCCESS);
     }
     else
     {
-        nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+        nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     }
 
     task_addr1 = rand();
@@ -463,7 +463,7 @@ void test_transmit_begin_ShallPrepareHardwareToTransmit(void)
     task_addr1 = rand();
     event_addr = rand();
 
-    nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_set_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_shorts_enable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 
     nrf_egu_event_address_get_ExpectAndReturn(NRF_802154_SWI_EGU_INSTANCE, EGU_EVENT, (uint32_t *)event_addr);
@@ -565,7 +565,7 @@ static void verify_tx_terminate_periph_reset(bool in_timeslot)
                              NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
                              NRF_TIMER_SHORT_COMPARE1_STOP_MASK);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
 
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_ppi_channel_disable_Expect(PPI_EGU_TIMER_START);
@@ -655,11 +655,11 @@ static void verify_phyend_ack_req_periph_setup(uint32_t shorts, bool buffer_free
                              NRF_TIMER_SHORT_COMPARE0_STOP_MASK |
                              NRF_TIMER_SHORT_COMPARE1_STOP_MASK);
 
-    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_pa_configuration_clear_ExpectAndReturn(&m_activate_tx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 
     // Set PPIs necessary in rx_ack state
-    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_set_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
 
     event_addr = rand();
     task_addr1 = rand();
@@ -867,7 +867,7 @@ static void verify_rx_ack_terminate_hardware_reset(bool in_timeslot)
     nrf_ppi_channel_disable_Expect(PPI_DISABLED_EGU);
     nrf_ppi_channel_disable_Expect(PPI_EGU_RAMP_UP);
 
-    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRF_SUCCESS);
+    nrf_802154_fal_lna_configuration_clear_ExpectAndReturn(&m_activate_rx_cc0, NULL, NRFX_SUCCESS);
     nrf_timer_task_trigger_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_shorts_disable_Expect(NRF_802154_TIMER_INSTANCE, NRF_TIMER_SHORT_COMPARE0_STOP_MASK);
 


### PR DESCRIPTION
In https://github.com/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver/pull/260 use of nrf_error.h and "NRF_SUCCESS" / "NRF_ERROR_*" macros was introduced.
but the official nrfx repository does use slightly different names.
this patch adapts the naming to work with the official nrfx repo.

please note that the changes were not tested extensively. they compile for me (tm), but you should run the internal unit tests. I was unable to figure out how to run them. it would be great to have a test-script to run these automatically.
