### PR TITLE
fix warning about several unused parameters

### DIFF
--- a/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
+++ b/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
@@ -102,6 +102,7 @@ static void fcf_sequence_number_suppression_set(const uint8_t * p_frame)
 
 static void fcf_ie_present_set(const uint8_t * p_frame, const uint8_t * p_ie_data)
 {
+    (void)p_frame;
     if (p_ie_data != NULL)
     {
         m_ack_data[IE_PRESENT_OFFSET] |= IE_PRESENT_BIT;
@@ -126,6 +127,7 @@ static void fcf_dst_addressing_mode_set(const uint8_t * p_frame)
 
 static void fcf_src_addressing_mode_set(const uint8_t * p_frame)
 {
+    (void)p_frame;
     m_ack_data[SRC_ADDR_TYPE_OFFSET] |= SRC_ADDR_TYPE_NONE;
 }
 
@@ -197,6 +199,7 @@ static void destination_set(const nrf_802154_frame_parser_mhr_data_t * p_frame,
 
 static void source_set(const uint8_t * p_frame)
 {
+    (void)p_frame;
     // Intentionally empty: source address type is None.
 }
 

--- a/src/mac_features/nrf_802154_filter.c
+++ b/src/mac_features/nrf_802154_filter.c
@@ -340,6 +340,7 @@ static bool dst_pan_id_check(const uint8_t * p_panid, uint8_t frame_type)
  */
 static bool dst_short_addr_check(const uint8_t * p_dst_addr, uint8_t frame_type)
 {
+    (void)frame_type;
     bool result;
 
     if ((0 == memcmp(p_dst_addr, nrf_802154_pib_short_address_get(), SHORT_ADDRESS_SIZE)) ||
@@ -366,6 +367,7 @@ static bool dst_short_addr_check(const uint8_t * p_dst_addr, uint8_t frame_type)
  */
 static bool dst_extended_addr_check(const uint8_t * p_dst_addr, uint8_t frame_type)
 {
+    (void)frame_type;
     bool result;
 
     if (0 == memcmp(p_dst_addr, nrf_802154_pib_extended_address_get(), EXTENDED_ADDRESS_SIZE))


### PR DESCRIPTION
if a recent gcc with -Wunused-parameter is used, it complains about these.