### PR TITLE
fix warning about invalid use of variadic macro without parameter

### DIFF
--- a/src/nrf_802154_request_direct.c
+++ b/src/nrf_802154_request_direct.c
@@ -42,12 +42,20 @@
 #include "nrf_802154_core.h"
 #include "nrf_radio.h"
 
-#define REQUEST_FUNCTION(func_core, ...) \
+#define REQUEST_FUNCTION_PARMS(func_core, ...) \
     bool result;                         \
                                          \
     result = func_core(__VA_ARGS__);     \
                                          \
     return result;
+
+#define REQUEST_FUNCTION(func_core)      \
+    bool result;                         \
+                                         \
+    result = func_core();                \
+                                         \
+    return result;
+
 
 void nrf_802154_request_init(void)
 {
@@ -56,7 +64,7 @@ void nrf_802154_request_init(void)
 
 bool nrf_802154_request_sleep(nrf_802154_term_t term_lvl)
 {
-    REQUEST_FUNCTION(nrf_802154_core_sleep, term_lvl)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_sleep, term_lvl)
 }
 
 bool nrf_802154_request_receive(nrf_802154_term_t              term_lvl,
@@ -64,7 +72,7 @@ bool nrf_802154_request_receive(nrf_802154_term_t              term_lvl,
                                 nrf_802154_notification_func_t notify_function,
                                 bool                           notify_abort)
 {
-    REQUEST_FUNCTION(nrf_802154_core_receive, term_lvl, req_orig, notify_function, notify_abort)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_receive, term_lvl, req_orig, notify_function, notify_abort)
 }
 
 bool nrf_802154_request_transmit(nrf_802154_term_t              term_lvl,
@@ -74,7 +82,7 @@ bool nrf_802154_request_transmit(nrf_802154_term_t              term_lvl,
                                  bool                           immediate,
                                  nrf_802154_notification_func_t notify_function)
 {
-    REQUEST_FUNCTION(nrf_802154_core_transmit,
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_transmit,
                      term_lvl,
                      req_orig,
                      p_data,
@@ -85,22 +93,22 @@ bool nrf_802154_request_transmit(nrf_802154_term_t              term_lvl,
 
 bool nrf_802154_request_energy_detection(nrf_802154_term_t term_lvl, uint32_t time_us)
 {
-    REQUEST_FUNCTION(nrf_802154_core_energy_detection, term_lvl, time_us)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_energy_detection, term_lvl, time_us)
 }
 
 bool nrf_802154_request_cca(nrf_802154_term_t term_lvl)
 {
-    REQUEST_FUNCTION(nrf_802154_core_cca, term_lvl)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_cca, term_lvl)
 }
 
 bool nrf_802154_request_continuous_carrier(nrf_802154_term_t term_lvl)
 {
-    REQUEST_FUNCTION(nrf_802154_core_continuous_carrier, term_lvl)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_continuous_carrier, term_lvl)
 }
 
 bool nrf_802154_request_buffer_free(uint8_t * p_data)
 {
-    REQUEST_FUNCTION(nrf_802154_core_notify_buffer_free, p_data)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_notify_buffer_free, p_data)
 }
 
 bool nrf_802154_request_channel_update(void)
@@ -120,5 +128,5 @@ bool nrf_802154_request_rssi_measure(void)
 
 bool nrf_802154_request_rssi_measurement_get(int8_t * p_rssi)
 {
-    REQUEST_FUNCTION(nrf_802154_core_last_rssi_measurement_get, p_rssi)
+    REQUEST_FUNCTION_PARMS(nrf_802154_core_last_rssi_measurement_get, p_rssi)
 }


### PR DESCRIPTION
recent GCC complains that:
ISO C99 requires at least one argument for the "..." in a variadic macro

so use a separate macro for functions without parameters.