### PR TITLE
Fix Coverity issues

### DIFF
--- a/examples/nrf_802154_delayed_echo_client/src/nrf_802154_delayed_echo_client.c
+++ b/examples/nrf_802154_delayed_echo_client/src/nrf_802154_delayed_echo_client.c
@@ -228,6 +228,7 @@ int main(void)
     frame_sequence_number_set(sequence_number_generate());
     nrf_802154_transmit_raw(mp_frame, true);
 
+    // coverity[no_escape]
     while (1)
     {
         __WFE();

--- a/examples/nrf_802154_delayed_echo_server/src/nrf_802154_delayed_echo_server.c
+++ b/examples/nrf_802154_delayed_echo_server/src/nrf_802154_delayed_echo_server.c
@@ -158,6 +158,7 @@ int main(void)
 
     nrf_802154_receive();
 
+    // coverity[no_escape]
     while (1)
     {
         __WFE();

--- a/examples/nrf_802154_echo_client/src/nrf_802154_echo_client.c
+++ b/examples/nrf_802154_echo_client/src/nrf_802154_echo_client.c
@@ -192,6 +192,7 @@ int main(void)
 
     frame_init();
 
+    // coverity[no_escape]
     while (1)
     {
         frame_sequence_number_set(sequence_number_generate());

--- a/examples/nrf_802154_echo_server/src/nrf_802154_echo_server.c
+++ b/examples/nrf_802154_echo_server/src/nrf_802154_echo_server.c
@@ -151,6 +151,7 @@ int main(void)
 
     nrf_802154_receive();
 
+    // coverity[no_escape]
     while (1)
     {
         __WFE();

--- a/nrf_802154_sl/platform/gpiote/nrf_802154_gpiote_none.c
+++ b/nrf_802154_sl/platform/gpiote/nrf_802154_gpiote_none.c
@@ -71,7 +71,9 @@ void nrf_802154_gpiote_init(void)
 
             nrf_802154_wifi_coex_cfg_3wire_get(&cfg);
 
+            // coverity[uninit_use]
             m_gpio_pin     = cfg.grant_cfg.gpio_pin;
+            // coverity[uninit_use]
             m_gpiote_ch_id = cfg.grant_cfg.gpiote_ch_id;
             assert(m_gpio_pin != COEX_GPIO_PIN_INVALID);
 

--- a/nrf_802154_sl/platform/irq/nrf_802154_irq_baremetal.c
+++ b/nrf_802154_sl/platform/irq/nrf_802154_irq_baremetal.c
@@ -68,30 +68,30 @@ void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr)
      */
     (void)isr;
 
-    NVIC_SetPriority(irqn, prio);
-    NVIC_ClearPendingIRQ(irqn);
+    NVIC_SetPriority((IRQn_Type)irqn, prio);
+    NVIC_ClearPendingIRQ((IRQn_Type)irqn);
 }
 
 void nrf_802154_irq_enable(uint32_t irqn)
 {
-    NVIC_EnableIRQ(irqn);
+    NVIC_EnableIRQ((IRQn_Type)irqn);
 }
 
 void nrf_802154_irq_disable(uint32_t irqn)
 {
-    NVIC_DisableIRQ(irqn);
+    NVIC_DisableIRQ((IRQn_Type)irqn);
     __DSB();
     __ISB();
 }
 
 void nrf_802154_irq_set_pending(uint32_t irqn)
 {
-    NVIC_SetPendingIRQ(irqn);
+    NVIC_SetPendingIRQ((IRQn_Type)irqn);
 }
 
 void nrf_802154_irq_clear_pending(uint32_t irqn)
 {
-    NVIC_ClearPendingIRQ(irqn);
+    NVIC_ClearPendingIRQ((IRQn_Type)irqn);
 }
 
 bool nrf_802154_irq_is_enabled(uint32_t irqn)
@@ -103,5 +103,5 @@ bool nrf_802154_irq_is_enabled(uint32_t irqn)
 
 uint32_t nrf_802154_irq_priority_get(uint32_t irqn)
 {
-    return NVIC_GetPriority(irqn);
+    return NVIC_GetPriority((IRQn_Type)irqn);
 }

--- a/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
+++ b/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
@@ -352,8 +352,8 @@ const uint8_t * nrf_802154_enh_ack_generator_create(const uint8_t * p_frame)
         return NULL;
     }
 
-    uint8_t         ie_data_len;
-    const uint8_t * p_ie_data = nrf_802154_ack_data_ie_get(
+    uint8_t         ie_data_len = 0;
+    const uint8_t * p_ie_data   = nrf_802154_ack_data_ie_get(
         frame_offsets.p_src_addr,
         frame_offsets.src_addr_size == EXTENDED_ADDRESS_SIZE,
         &ie_data_len);

--- a/src/mac_features/nrf_802154_delayed_trx.c
+++ b/src/mac_features/nrf_802154_delayed_trx.c
@@ -493,8 +493,8 @@ bool nrf_802154_delayed_trx_transmit_cancel(void)
 
 bool nrf_802154_delayed_trx_receive_cancel(void)
 {
-    bool result = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_RX);
-    bool was_running;
+    bool result      = nrf_802154_rsch_delayed_timeslot_cancel(RSCH_DLY_RX);
+    bool was_running = false;
 
     nrf_802154_timer_sched_remove(&m_timeout_timer, &was_running);
 

--- a/src/mac_features/nrf_802154_frame_parser.c
+++ b/src/mac_features/nrf_802154_frame_parser.c
@@ -264,7 +264,14 @@ static uint8_t security_offset_get(const uint8_t * p_frame)
 
 static uint8_t key_id_size_get(const uint8_t * p_frame)
 {
-    switch (*nrf_802154_frame_parser_sec_ctrl_get(p_frame) & KEY_ID_MODE_MASK)
+    const uint8_t * p_sec_ctrl = nrf_802154_frame_parser_sec_ctrl_get(p_frame);
+
+    if (p_sec_ctrl == NULL)
+    {
+        return 0;
+    }
+
+    switch (*p_sec_ctrl & KEY_ID_MODE_MASK)
     {
         case KEY_ID_MODE_1:
             return KEY_ID_MODE_1_SIZE;

--- a/src/mac_features/nrf_802154_ifs.c
+++ b/src/mac_features/nrf_802154_ifs.c
@@ -218,8 +218,8 @@ void nrf_802154_ifs_transmitted_hook(const uint8_t * p_frame)
 
 bool nrf_802154_ifs_abort(nrf_802154_term_t term_lvl, req_originator_t req_orig)
 {
-    bool result = true;
-    bool was_running;
+    bool result      = true;
+    bool was_running = false;
 
     if (req_orig == REQ_ORIG_IFS)
     {

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -116,7 +116,7 @@ void nrf_802154_channel_set(uint8_t channel)
 
     if (changed)
     {
-        nrf_802154_request_channel_update();
+        (void)nrf_802154_request_channel_update();
     }
 }
 

--- a/src/nrf_802154_core.c
+++ b/src/nrf_802154_core.c
@@ -249,7 +249,7 @@ static uint8_t lqi_get(const uint8_t * p_data)
  */
 static uint32_t timer_coord_timestamp_get(void)
 {
-    uint32_t timestamp;
+    uint32_t timestamp          = NRF_802154_NO_TIMESTAMP;
     bool     timestamp_received = nrf_802154_timer_coord_timestamp_get(&timestamp);
 
     if (!timestamp_received)
@@ -2127,6 +2127,7 @@ static bool ack_match_check_version_2(const uint8_t * p_tx_data, const uint8_t *
 
     parse_result = nrf_802154_frame_parser_mhr_parse(p_tx_data, &tx_mhr_data);
     assert(parse_result);
+    (void)parse_result;
     parse_result = nrf_802154_frame_parser_mhr_parse(p_ack_data, &ack_mhr_data);
 
     if (!parse_result ||
@@ -2465,7 +2466,7 @@ bool nrf_802154_core_transmit(nrf_802154_term_t              term_lvl,
 
     if (result)
     {
-        /* Short-circuit evaluation in place. */
+        // Short-circuit evaluation in place.
         if ((immediate) || (nrf_802154_core_hooks_pre_transmission(p_data, cca)))
         {
             result = current_operation_terminate(term_lvl, req_orig, true);
@@ -2481,6 +2482,7 @@ bool nrf_802154_core_transmit(nrf_802154_term_t              term_lvl,
                 state_set(cca ? RADIO_STATE_CCA_TX : RADIO_STATE_TX);
                 mp_tx_data = p_data;
 
+                // coverity[check_return]
                 result = tx_init(p_data, cca);
                 if (immediate)
                 {

--- a/src/nrf_802154_critical_section.c
+++ b/src/nrf_802154_critical_section.c
@@ -196,8 +196,6 @@ static void critical_section_exit(void)
                 result = critical_section_enter(false);
                 assert(result);
                 (void)result;
-
-                continue;
             }
             else
             {

--- a/src/nrf_802154_debug_assert.c
+++ b/src/nrf_802154_debug_assert.c
@@ -56,6 +56,7 @@ void __assert_func(const char * file, int line, const char * func, const char * 
 #endif
     __disable_irq();
 
+    // coverity[no_escape]
     while (1)
         ;
 }
@@ -71,6 +72,7 @@ void __aeabi_assert(const char * expr, const char * file, int line)
 #endif
     __disable_irq();
 
+    // coverity[no_escape]
     while (1)
         ;
 }

--- a/src/nrf_802154_trx.c
+++ b/src/nrf_802154_trx.c
@@ -670,6 +670,7 @@ static void rx_antenna_update(void)
     }
 
     assert(result);
+    (void)result;
 }
 
 /**


### PR DESCRIPTION
Fix detections with potentially real impact.
Suppress false positives by adding comments: coverity[tag]

The Coverity analysis report can be found here: [Jenkins-run#9](https://jenkins-ncs.nordicsemi.no/blue/organizations/jenkins/latest%2Ftest-fw-nrfconnect-rs_drv154_integration/detail/fix%2FKRKNWK-8993-coverity_fixes_check/9/artifacts/) (no detections)